### PR TITLE
Fix/allow default value

### DIFF
--- a/src/main/java/org/kestra/task/serdes/avro/AvroConverter.java
+++ b/src/main/java/org/kestra/task/serdes/avro/AvroConverter.java
@@ -76,8 +76,7 @@ public class AvroConverter {
 
         for (Schema.Field field : schema.getFields()) {
             try {
-                record.put(field.name(), convert(field.schema(), data.get(field.name())));
-            } catch (IllegalCellConversion e) {
+            } catch (IllegalCellConversion | NullPointerException e) {
                 throw new IllegalRowConvertion(data, e, field);
             }
         }
@@ -366,6 +365,10 @@ public class AvroConverter {
     }
 
     public String primitiveString(Object data) {
+        if (data == null) {
+            throw new NullPointerException("Invalid object with null data");
+        }
+
         return String.valueOf(data);
     }
 

--- a/src/test/java/org/kestra/task/serdes/avro/AvroConverterTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/AvroConverterTest.java
@@ -129,6 +129,7 @@ public class AvroConverterTest {
             GenericData.Record record = avroConverter.fromMap(schema, map);
             GenericRecord serialized = Utils.test(schema, record);
 
+
             assertThat(record, is(serialized));
             assertThat(serialized.get("fieldName"), is(expected));
         }
@@ -139,6 +140,39 @@ public class AvroConverterTest {
             Map<String, Object> data = new HashMap<>(); // Map instead of ImmutableMap to allow null values
             data.put("fieldName", v);
             assertThrows(AvroConverter.IllegalRowConvertion.class, () -> avroConverter.fromMap(schema, data));
+        }
+
+        static void testRecord(Schema type, Map<String, Object> v, Map<String, Object> expected) throws Exception {
+            try {
+                AvroConverter avroConverter = AvroConverter.builder().build();
+                Schema schema = oneFieldSchema(type);
+
+                HashMap<String, Object> mapV = new HashMap<>();
+                mapV.put("fieldName", v);
+
+                HashMap<String, Object> mapExpected = new HashMap<>();
+                mapExpected.put("fieldName", expected);
+
+                GenericData.Record recordV = avroConverter.fromMap(schema, mapV);
+                GenericRecord serializedV = AvroConverterTest.Utils.test(schema, recordV);
+                GenericData.Record recordExpected = avroConverter.fromMap(schema, mapExpected);
+                GenericRecord serializedExpected = AvroConverterTest.Utils.test(schema, recordExpected);
+                assertThat(recordV, is(serializedV));
+                assertThat(serializedV, is(serializedExpected));
+            } catch (AvroConverter.IllegalRowConvertion | AssertionError e) {
+                throw new Exception(e);
+            }
+        }
+
+        public static void testRecordOk(Schema type, Map<String, Object> v, Map<String, Object> expected) {
+            try {testRecord(type, v, expected);} catch (Exception e) { throw new RuntimeException(e);}
+        }
+
+        public static void testRecordKo(Schema type, Map<String, Object> v, Map<String, Object> expected) {
+            try {
+                testRecord(type, v, expected);
+            } catch (Exception ignored) {} // for debug purpose, can't debug lambda, BP here
+            assertThrows(Exception.class, () -> testRecord(type, v, expected));
         }
 
         public static Schema oneFieldSchema(Schema type) {

--- a/src/test/java/org/kestra/task/serdes/avro/AvroConverterTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/AvroConverterTest.java
@@ -23,6 +23,7 @@ import org.kestra.task.serdes.json.JsonReader;
 import java.io.*;
 import java.net.URI;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import javax.inject.Inject;
@@ -135,8 +136,9 @@ public class AvroConverterTest {
         public static void oneFieldFailed(Object v, Schema type) {
             AvroConverter avroConverter = AvroConverter.builder().build();
             Schema schema = oneFieldSchema(type);
-
-            assertThrows(AvroConverter.IllegalRowConvertion.class, () -> avroConverter.fromMap(schema, ImmutableMap.of("fieldName", v)));
+            Map<String, Object> data = new HashMap<>(); // Map instead of ImmutableMap to allow null values
+            data.put("fieldName", v);
+            assertThrows(AvroConverter.IllegalRowConvertion.class, () -> avroConverter.fromMap(schema, data));
         }
 
         public static Schema oneFieldSchema(Schema type) {

--- a/src/test/java/org/kestra/task/serdes/avro/AvroConverterTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/AvroConverterTest.java
@@ -129,7 +129,7 @@ public class AvroConverterTest {
             GenericData.Record record = avroConverter.fromMap(schema, map);
             GenericRecord serialized = Utils.test(schema, record);
 
-
+            new GenericData().validate(schema, serialized);
             assertThat(record, is(serialized));
             assertThat(serialized.get("fieldName"), is(expected));
         }

--- a/src/test/java/org/kestra/task/serdes/avro/converter/ComplexArrayTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/ComplexArrayTest.java
@@ -28,8 +28,9 @@ public class ComplexArrayTest {
     static Stream<Arguments> failedSource() {
         return Stream.of(
             Arguments.of(Arrays.asList("a", 42.2), Schema.create(Schema.Type.FLOAT)),
-            Arguments.of(Arrays.asList("null", "a"), Schema.createUnion(Schema.create(Schema.Type.BOOLEAN), Schema.create(Schema.Type.NULL)))
-
+            Arguments.of(Arrays.asList("null", "a"), Schema.createUnion(Schema.create(Schema.Type.BOOLEAN), Schema.create(Schema.Type.NULL))),
+            Arguments.of((Object) null, Schema.create(Schema.Type.FLOAT)),
+            Arguments.of(Arrays.asList(1.1, null), Schema.create(Schema.Type.FLOAT))
         );
     }
 

--- a/src/test/java/org/kestra/task/serdes/avro/converter/ComplexMapTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/ComplexMapTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Stream;
 
 public class ComplexMapTest {
     static Stream<Arguments> source() {
+        // TODO test null (not "null") in Map
         return Stream.of(
             Arguments.of(
                 ImmutableMap.of("a", 42.2D, "b", "42", "c", 42.2D),

--- a/src/test/java/org/kestra/task/serdes/avro/converter/ComplexUnionTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/ComplexUnionTest.java
@@ -23,11 +23,34 @@ public class ComplexUnionTest {
             Arguments.of("n/a", Arrays.asList(Schema.Type.STRING, Schema.Type.NULL), new Utf8("n/a"))
         );
     }
-    //TODO test invalid Union
+
+    static Stream<Arguments> invalidSource() {
+        return Stream.of(
+            Arguments.of("toto", Arrays.asList(Schema.Type.NULL, Schema.Type.BOOLEAN)),
+            Arguments.of(null, Arrays.asList(Schema.Type.STRING, Schema.Type.BOOLEAN)),
+            //TODO reflexion intime
+            // Arguments.of("null", Arrays.asList(Schema.Type.BOOLEAN, Schema.Type.STRING)),
+            Arguments.of(10000000L, Arrays.asList(Schema.Type.INT, Schema.Type.NULL)),
+            Arguments.of(false, Arrays.asList(Schema.Type.INT, Schema.Type.NULL))
+            //TODO reflexion time
+            // Arguments.of("", Arrays.asList(Schema.Type.INT, Schema.Type.STRING, Schema.Type.FLOAT))
+        );
+    }
+
     @ParameterizedTest
     @MethodSource("source")
     void convert(Object v, List<Schema.Type> schemas, Object expected) throws Exception {
         AvroConverterTest.Utils.oneField(v, expected, Schema.createUnion(schemas
+            .stream()
+            .map(Schema::create)
+            .collect(Collectors.toList())
+        ));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidSource")
+    void testInvalidUnion(Object v, List<Schema.Type> schemas) {
+        AvroConverterTest.Utils.oneFieldFailed(v, Schema.createUnion(schemas
             .stream()
             .map(Schema::create)
             .collect(Collectors.toList())

--- a/src/test/java/org/kestra/task/serdes/avro/converter/ComplexUnionTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/ComplexUnionTest.java
@@ -15,14 +15,15 @@ import java.util.stream.Stream;
 public class ComplexUnionTest {
     static Stream<Arguments> source() {
         return Stream.of(
-            Arguments.of("null", Arrays.asList(Schema.Type.NULL, Schema.Type.BOOLEAN),  null),
-            Arguments.of("null", Arrays.asList(Schema.Type.BOOLEAN, Schema.Type.NULL),  null),
+            Arguments.of("null", Arrays.asList(Schema.Type.NULL, Schema.Type.BOOLEAN), null),
+            Arguments.of(null, Arrays.asList(Schema.Type.NULL, Schema.Type.BOOLEAN), null),
+            Arguments.of("null", Arrays.asList(Schema.Type.BOOLEAN, Schema.Type.NULL), null),
             Arguments.of("1", Arrays.asList(Schema.Type.INT, Schema.Type.NULL), 1),
             Arguments.of("n/a", Arrays.asList(Schema.Type.NULL, Schema.Type.STRING), null),
-            Arguments.of("n/a", Arrays.asList(Schema.Type.STRING, Schema.Type.NULL),  new Utf8("n/a"))
+            Arguments.of("n/a", Arrays.asList(Schema.Type.STRING, Schema.Type.NULL), new Utf8("n/a"))
         );
     }
-
+    //TODO test invalid Union
     @ParameterizedTest
     @MethodSource("source")
     void convert(Object v, List<Schema.Type> schemas, Object expected) throws Exception {

--- a/src/test/java/org/kestra/task/serdes/avro/converter/LogicalDateTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/LogicalDateTest.java
@@ -34,6 +34,7 @@ class LogicalDateTest {
         AvroConverterTest.Utils.oneField(v, expected, schema);
     }
 
+    // FIXME if you add "null" to the list, you expect it to fail, but it surprisingly succeed
     Stream<Arguments> failedSource() {
         return Stream.of(
             Arguments.of("12-26-2019"),

--- a/src/test/java/org/kestra/task/serdes/avro/converter/LogicalDateTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/LogicalDateTest.java
@@ -2,12 +2,12 @@ package org.kestra.task.serdes.avro.converter;
 
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
-import org.kestra.task.serdes.avro.AvroConverterTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.kestra.task.serdes.avro.AvroConverterTest;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -34,9 +34,10 @@ class LogicalDateTest {
         AvroConverterTest.Utils.oneField(v, expected, schema);
     }
 
-    // FIXME if you add "null" to the list, you expect it to fail, but it surprisingly succeed
     Stream<Arguments> failedSource() {
         return Stream.of(
+            Arguments.of((Object) null),
+            Arguments.of("jacky"),
             Arguments.of("12-26-2019"),
             Arguments.of("2019-12+0100")
         );

--- a/src/test/java/org/kestra/task/serdes/avro/converter/LogicalDateTimeTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/LogicalDateTimeTest.java
@@ -50,6 +50,7 @@ public class LogicalDateTimeTest {
         AvroConverterTest.Utils.oneField(avroConverter, v, expected, LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG)));
     }
 
+    // FIXME if you add "null" to the list, you expect it to fail, but it surprisingly succeed
     static Stream<Arguments> failedSource() {
         return Stream.of(
             Arguments.of("12:26:2019")

--- a/src/test/java/org/kestra/task/serdes/avro/converter/LogicalDateTimeTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/LogicalDateTimeTest.java
@@ -53,6 +53,8 @@ public class LogicalDateTimeTest {
     // FIXME if you add "null" to the list, you expect it to fail, but it surprisingly succeed
     static Stream<Arguments> failedSource() {
         return Stream.of(
+            Arguments.of((Object) null),
+            Arguments.of((String) null),
             Arguments.of("12:26:2019")
         );
     }

--- a/src/test/java/org/kestra/task/serdes/avro/converter/LogicalDecimalTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/LogicalDecimalTest.java
@@ -27,7 +27,7 @@ public class LogicalDecimalTest {
             Arguments.of(12.8444D, new BigDecimal("12.84"), 4, 2),
             Arguments.of(12.8444F, new BigDecimal("12.84"), 4, 2),
             Arguments.of("2019", new BigDecimal("2019"), 4, 0)
-        );
+            );
     }
 
     @ParameterizedTest
@@ -55,4 +55,6 @@ public class LogicalDecimalTest {
             LogicalTypes.decimal(precision, scale).addToSchema(Schema.create(Schema.Type.BYTES))
         );
     }
+
+    // TODO add invalid Decimal test (test null, precision not big enough, scale not big enough, ...)
 }

--- a/src/test/java/org/kestra/task/serdes/avro/converter/LogicalDecimalTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/LogicalDecimalTest.java
@@ -2,39 +2,45 @@ package org.kestra.task.serdes.avro.converter;
 
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
-import org.kestra.task.serdes.avro.AvroConverter;
-import org.kestra.task.serdes.avro.AvroConverterTest;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.kestra.task.serdes.avro.AvroConverter;
+import org.kestra.task.serdes.avro.AvroConverterTest;
 
 import java.math.BigDecimal;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
-
 public class LogicalDecimalTest {
-    static Stream<Arguments> source() {
+    static Stream<Arguments> validSource() {
         return Stream.of(
+            Arguments.of("1", new BigDecimal("1"), 1, 0),
+            Arguments.of("1", new BigDecimal("1"), 100, 0),
             Arguments.of("12.82", new BigDecimal("12.82"), 4, 2),
             Arguments.of("12.8", new BigDecimal("12.80"), 4, 2),
             Arguments.of(12.8F, new BigDecimal("12.80"), 4, 2),
             Arguments.of("12.828282", new BigDecimal("12.828282"), 8, 6),
+            Arguments.of("12", new BigDecimal("12.00"), 4, 2),
+            Arguments.of("12.000000", new BigDecimal("12.00"), 4, 2),
             Arguments.of(12L, new BigDecimal("12.00"), 4, 2),
             Arguments.of(12, new BigDecimal("12.00"), 4, 2),
-            Arguments.of(12.8444D, new BigDecimal("12.84"), 4, 2),
-            Arguments.of(12.8444F, new BigDecimal("12.84"), 4, 2),
-            Arguments.of("2019", new BigDecimal("2019"), 4, 0)
-            );
+            Arguments.of(12.84D, new BigDecimal("12.84"), 4, 2),
+            Arguments.of(12.84F, new BigDecimal("12.84"), 4, 2),
+            Arguments.of("2019", new BigDecimal("2019"), 4, 0),
+            Arguments.of(2019, new BigDecimal("2019"), 4, 0)
+        );
     }
 
-    @ParameterizedTest
-    @MethodSource("source")
-    void convert(Object v, BigDecimal expected, Integer precision, Integer scale) throws Exception {
-        Schema schema = LogicalTypes.decimal(precision, scale).addToSchema(Schema.create(Schema.Type.BYTES));
-        AvroConverterTest.Utils.oneField(v, expected, schema);
+    static Stream<Arguments> invalidSource() {
+        return Stream.of(
+            Arguments.of(null, 4, 2),
+            Arguments.of("tata", 4, 2),
+            Arguments.of("", 4, 2),
+            Arguments.of(100, 2, 0),
+            Arguments.of("100", 2, 0),
+            Arguments.of("111.11", 4, 1),
+            Arguments.of("0.01", 4, 1)
+        );
     }
 
     static Stream<Arguments> separator() {
@@ -43,6 +49,20 @@ public class LogicalDecimalTest {
             Arguments.of("12,82", new BigDecimal("12.82"), 4, 2, ','),
             Arguments.of("12|82", new BigDecimal("12.82"), 4, 2, '|')
         );
+    }
+
+    @ParameterizedTest
+    @MethodSource("validSource")
+    void convert(Object v, BigDecimal expected, Integer precision, Integer scale) throws Exception {
+        Schema schema = LogicalTypes.decimal(precision, scale).addToSchema(Schema.create(Schema.Type.BYTES));
+        AvroConverterTest.Utils.oneField(v, expected, schema);
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidSource")
+    void testFail(Object v, Integer precision, Integer scale) {
+        Schema schema = LogicalTypes.decimal(precision, scale).addToSchema(Schema.create(Schema.Type.BYTES));
+        AvroConverterTest.Utils.oneFieldFailed(v, schema);
     }
 
     @ParameterizedTest
@@ -56,5 +76,4 @@ public class LogicalDecimalTest {
         );
     }
 
-    // TODO add invalid Decimal test (test null, precision not big enough, scale not big enough, ...)
 }

--- a/src/test/java/org/kestra/task/serdes/avro/converter/LogicalTimeTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/LogicalTimeTest.java
@@ -29,6 +29,7 @@ public class LogicalTimeTest {
         AvroConverterTest.Utils.oneField(v, expected, LogicalTypes.timeMillis().addToSchema(Schema.create(Schema.Type.INT)));
     }
 
+    // FIXME if you add "null" to the list, you expect it to fail, but it surprisingly succeed
     static Stream<Arguments> failedSource() {
         return Stream.of(
             Arguments.of("12:26:2019"),

--- a/src/test/java/org/kestra/task/serdes/avro/converter/LogicalTimeTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/LogicalTimeTest.java
@@ -29,9 +29,11 @@ public class LogicalTimeTest {
         AvroConverterTest.Utils.oneField(v, expected, LogicalTypes.timeMillis().addToSchema(Schema.create(Schema.Type.INT)));
     }
 
-    // FIXME if you add "null" to the list, you expect it to fail, but it surprisingly succeed
     static Stream<Arguments> failedSource() {
         return Stream.of(
+            Arguments.of((Object)null),
+            Arguments.of(1235),
+            Arguments.of(12.35),
             Arguments.of("12:26:2019"),
             Arguments.of("12+0100")
         );

--- a/src/test/java/org/kestra/task/serdes/avro/converter/LogicalUuidTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/LogicalUuidTest.java
@@ -25,6 +25,7 @@ public class LogicalUuidTest {
         AvroConverterTest.Utils.oneField(v, expected, schema);
     }
 
+    // FIXME if you add "null" to the list, you expect it to fail, but it surprisingly succeed
     static Stream<Arguments> failedSource() {
         return Stream.of(
             Arguments.of("123e4567"),

--- a/src/test/java/org/kestra/task/serdes/avro/converter/LogicalUuidTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/LogicalUuidTest.java
@@ -25,9 +25,10 @@ public class LogicalUuidTest {
         AvroConverterTest.Utils.oneField(v, expected, schema);
     }
 
-    // FIXME if you add "null" to the list, you expect it to fail, but it surprisingly succeed
     static Stream<Arguments> failedSource() {
         return Stream.of(
+            Arguments.of((Object) null),
+            Arguments.of(1),
             Arguments.of("123e4567"),
             Arguments.of("123e4567e89b12d3a456556642440000")
         );

--- a/src/test/java/org/kestra/task/serdes/avro/converter/PrimitiveBoolTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/PrimitiveBoolTest.java
@@ -21,7 +21,7 @@ public class PrimitiveBoolTest {
             Arguments.of(0, false),
             Arguments.of("", false),
             Arguments.of(false, false)
-        );
+            );
     }
 
     @ParameterizedTest
@@ -29,4 +29,6 @@ public class PrimitiveBoolTest {
     void convert(Object v, boolean expected) throws Exception {
         AvroConverterTest.Utils.oneField(v, expected, Schema.create(Schema.Type.BOOLEAN));
     }
+
+    // TODO test wrong value
 }

--- a/src/test/java/org/kestra/task/serdes/avro/converter/PrimitiveBoolTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/PrimitiveBoolTest.java
@@ -6,10 +6,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.stream.Stream;
 
 public class PrimitiveBoolTest {
-    static Stream<Arguments> source() {
+    static Stream<Arguments> validSource() {
         return Stream.of(
             Arguments.of("true", true),
             Arguments.of("True", true),
@@ -19,16 +21,30 @@ public class PrimitiveBoolTest {
             Arguments.of("False", false),
             Arguments.of("0", false),
             Arguments.of(0, false),
-            Arguments.of("", false),
             Arguments.of(false, false)
             );
     }
 
     @ParameterizedTest
-    @MethodSource("source")
+    @MethodSource("validSource")
     void convert(Object v, boolean expected) throws Exception {
         AvroConverterTest.Utils.oneField(v, expected, Schema.create(Schema.Type.BOOLEAN));
     }
 
-    // TODO test wrong value
+    static Stream<Arguments> invalidSource() {
+        return Stream.of(
+            Arguments.of("toto"),
+            Arguments.of(2L),
+            Arguments.of('a'),
+            Arguments.of((Object) null),
+            Arguments.of(""),
+            Arguments.of(new ArrayList<>()),
+            Arguments.of(new HashMap<>())
+        );
+    }
+    @ParameterizedTest
+    @MethodSource("invalidSource")
+    void invalidBoolTest(Object v) {
+        AvroConverterTest.Utils.oneFieldFailed(v, Schema.create(Schema.Type.BOOLEAN));
+    }
 }

--- a/src/test/java/org/kestra/task/serdes/avro/converter/PrimitiveFloatTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/PrimitiveFloatTest.java
@@ -51,7 +51,8 @@ public class PrimitiveFloatTest {
     static Stream<Arguments> failedSource() {
         return Stream.of(
             Arguments.of("a"),
-            Arguments.of(9223372036854775807L)
+            Arguments.of(9223372036854775807L),
+            Arguments.of((Object) null)
         );
     }
 

--- a/src/test/java/org/kestra/task/serdes/avro/converter/PrimitiveIntTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/PrimitiveIntTest.java
@@ -30,7 +30,8 @@ public class PrimitiveIntTest {
             Arguments.of(42.2D),
             Arguments.of(42.2F),
             Arguments.of("a"),
-            Arguments.of(9223372036854775807L)
+            Arguments.of(9223372036854775807L),
+            Arguments.of((Object) null)
         );
     }
 

--- a/src/test/java/org/kestra/task/serdes/avro/converter/PrimitiveLongTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/PrimitiveLongTest.java
@@ -31,7 +31,8 @@ class PrimitiveLongTest {
             Arguments.of(42.2D),
             Arguments.of(42.2F),
             Arguments.of("a"),
-            Arguments.of("9223372036854775808")
+            Arguments.of("9223372036854775808"),
+            Arguments.of((Object) null)
         );
     }
 

--- a/src/test/java/org/kestra/task/serdes/avro/converter/PrimitiveNullTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/PrimitiveNullTest.java
@@ -14,7 +14,8 @@ public class PrimitiveNullTest {
             Arguments.of("NULL", null),
             Arguments.of("n/a", null),
             Arguments.of("N/A", null),
-            Arguments.of("", null)
+            Arguments.of("", null),
+            Arguments.of(null, null)
         );
     }
 

--- a/src/test/java/org/kestra/task/serdes/avro/converter/PrimitiveStringBytesTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/PrimitiveStringBytesTest.java
@@ -2,20 +2,19 @@ package org.kestra.task.serdes.avro.converter;
 
 import org.apache.avro.Schema;
 import org.apache.avro.util.Utf8;
-import org.kestra.task.serdes.avro.AvroConverterTest;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.kestra.task.serdes.avro.AvroConverterTest;
 
 import java.nio.ByteBuffer;
 import java.util.stream.Stream;
 
 public class PrimitiveStringBytesTest {
-    static Stream<Arguments> source() {
+    static Stream<Arguments> validSource() {
         return Stream.of(
             Arguments.of("a", "a"),
             Arguments.of("true", "true"),
-            Arguments.of(null, "null"),
             Arguments.of(1, "1"),
             Arguments.of(42D, "42.0"),
             Arguments.of(42F, "42.0"),
@@ -26,14 +25,26 @@ public class PrimitiveStringBytesTest {
     }
 
     @ParameterizedTest
-    @MethodSource("source")
+    @MethodSource("validSource")
     void convert(Object v, String expected) throws Exception {
         AvroConverterTest.Utils.oneField(v, new Utf8(expected.getBytes()), Schema.create(Schema.Type.STRING));
     }
 
     @ParameterizedTest
-    @MethodSource("source")
-    static void convertBytes(Object v, String expected) throws Exception {
+    @MethodSource("validSource")
+    void convertBytes(Object v, String expected) throws Exception {
         AvroConverterTest.Utils.oneField(v, ByteBuffer.wrap(new Utf8(expected.getBytes()).getBytes()), Schema.create(Schema.Type.BYTES));
+    }
+
+    static Stream<Arguments> invalidSource() {
+        return Stream.of(
+            Arguments.of((Object) null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidSource")
+    void invalidStringTest(Object v) {
+        AvroConverterTest.Utils.oneFieldFailed(v, Schema.create(Schema.Type.STRING));
     }
 }

--- a/src/test/java/org/kestra/task/serdes/avro/converter/RecordTest.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/RecordTest.java
@@ -1,0 +1,99 @@
+package org.kestra.task.serdes.avro.converter;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kestra.task.serdes.avro.AvroConverter;
+import org.kestra.task.serdes.avro.AvroConverterTest;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.kestra.task.serdes.avro.AvroConverterTest.Utils.oneFieldSchema;
+
+public class RecordTest {
+    static String json(String str) {
+        return str.replace("'", "\"");
+    }
+
+    static final String SCHEMA_WITHOUT_DEFAULT = json("{"
+        + "'type': 'record', 'name': 'toto', 'fields': ["
+        + "{'name': 'id', 'type': 'int'},"
+        + "{'name': 'label', 'type': 'string'}"
+        + "]}");
+
+    static final String SCHEMA_WITH_DEFAULT = json("{"
+        + "'type': 'record', 'name': 'toto', 'fields': ["
+        + "{'name': 'id', 'type': 'int'},"
+        + "{'name': 'label', 'type': 'string', 'default':'foo'}"
+        + "]}");
+
+    static final String SCHEMA_WITHOUT_DEFAULT_NULLABLE = json("{"
+        + "'type': 'record', 'name': 'toto', 'fields': ["
+        + "{'name': 'id', 'type': 'int'},"
+        + "{'name': 'label', 'type': ['null','string']}"
+        + "]}");
+
+    static final String SCHEMA_WITH_DEFAULT_NULLABLE = json("{"
+        + "'type': 'record', 'name': 'toto', 'fields': ["
+        + "{'name': 'id', 'type': 'int'},"
+        + "{'name': 'label', 'type': ['string','null'], 'default': 'foo'}"
+        + "]}");
+
+    static Map<String, Object> recordFull = new HashMap<>();
+    static Map<String, Object> recordNullValue = new HashMap<>();
+    static Map<String, Object> recordMissingValue = new HashMap<>();
+
+
+    static {
+        recordFull.put("id", 1);
+        recordFull.put("label", "foo");
+
+        recordNullValue.put("id", 1);
+        recordNullValue.put("label", null);
+
+        recordMissingValue.put("id", 1);
+    }
+
+    public static Stream<Arguments> source() {
+        return Stream.of(
+            Arguments.of(SCHEMA_WITHOUT_DEFAULT, recordFull, recordFull, true),
+            Arguments.of(SCHEMA_WITHOUT_DEFAULT, recordNullValue, recordFull, false),
+            Arguments.of(SCHEMA_WITHOUT_DEFAULT, recordMissingValue, recordFull, false),
+
+            Arguments.of(SCHEMA_WITH_DEFAULT, recordMissingValue, recordFull, true),
+            Arguments.of(SCHEMA_WITH_DEFAULT, recordFull, recordFull, true),
+            Arguments.of(SCHEMA_WITH_DEFAULT, recordNullValue, recordFull, false),
+
+            Arguments.of(SCHEMA_WITHOUT_DEFAULT_NULLABLE, recordFull, recordFull, true),
+            Arguments.of(SCHEMA_WITHOUT_DEFAULT_NULLABLE, recordNullValue, recordNullValue, true),
+            Arguments.of(SCHEMA_WITHOUT_DEFAULT_NULLABLE, recordMissingValue, recordFull, false),
+
+            Arguments.of(SCHEMA_WITH_DEFAULT_NULLABLE, recordFull, recordFull, true),
+            Arguments.of(SCHEMA_WITH_DEFAULT_NULLABLE, recordNullValue, recordNullValue, true),
+            Arguments.of(SCHEMA_WITH_DEFAULT_NULLABLE, recordMissingValue, recordFull, true)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("source")
+    void sourceWithoutDefaultOkTest(String schema,
+                                    HashMap<String, Object> v,
+                                    HashMap<String, Object> expected,
+                                    boolean working) {
+        Schema type = new Schema.Parser().parse(json(schema));
+        if (working) {
+            AvroConverterTest.Utils.testRecordOk(type, v, expected);
+        } else {
+            AvroConverterTest.Utils.testRecordKo(type, v, expected);
+        }
+    }
+
+}

--- a/src/test/java/org/kestra/task/serdes/avro/converter/TestDefaultValue.java
+++ b/src/test/java/org/kestra/task/serdes/avro/converter/TestDefaultValue.java
@@ -1,0 +1,52 @@
+package org.kestra.task.serdes.avro.converter;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kestra.task.serdes.avro.AvroConverter;
+import org.kestra.task.serdes.avro.AvroConverterTest;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.kestra.task.serdes.avro.AvroConverterTest.Utils.oneFieldSchema;
+
+public class TestDefaultValue {
+    static String json(String str) {
+        return str.replace("'", "\"");
+    }
+
+    static final String SCHEMA = json("{'name': 'root', 'type': 'record', 'fields': [{'name': 'id', 'type': ['null','int']}]}");
+
+    static final Map<String, Object> empty = new HashMap<>();
+    static final Map<String, Object> expected = new HashMap<>();
+
+    static {expected.put("id", null);}
+
+    @Test
+    void testWithDefaultIsNull() {
+        Schema schema = new Schema.Parser().parse(SCHEMA);
+        AvroConverter avroConverter = AvroConverter.builder().missingDefaultIsNull(true).build();
+        try {
+            assertThat(avroConverter.fromMap(schema, empty), is(avroConverter.fromMap(schema, expected)));
+        } catch (AvroConverter.IllegalRowConvertion e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void testWithDefaultNotIsNull() {
+        Schema schema = new Schema.Parser().parse(SCHEMA);
+        AvroConverter avroConverter = AvroConverter.builder().missingDefaultIsNull(false).build();
+        try {avroConverter.fromMap(schema, empty);} catch (Exception ignored) {}
+        assertThrows(AvroConverter.IllegalRowConvertion.class, () -> avroConverter.fromMap(schema, empty));
+    }
+}


### PR DESCRIPTION
I don't even remember why, but while working on avro compatibility check, we found out strange behaviour by the parser if it encounter null value while parsing String. While trying to fix that, a lot of stuff popped out.

We used that opportunity to fix handling of "null" and implement "default" field value (avro spec).
We also added a parameter "missingDefaultIsNull", that put "null" as "default" if no default is given

More info on why this is needed on https://issues.apache.org/jira/browse/AVRO-1803
(no "null" default means that if key isn't found in the record, the record is invalid)

This parameter is "true" by default for simplicity and avoid breaking compatibility

It **SHOULD** not break anything, UT still works, but it might, has before, in the `fromMap` method of `AvroConverter`, the only line was
```java
record.put(field.name(), convert(field.schema(), data.get(field.name())));
```
this didn't check if the key existed in the record, `Map().get()` returns null if the key doesn't exist