### PR TITLE
fix: Snappy write the native dir in /tmp

### DIFF
--- a/src/main/java/io/kestra/plugin/serdes/parquet/IonToParquet.java
+++ b/src/main/java/io/kestra/plugin/serdes/parquet/IonToParquet.java
@@ -129,6 +129,10 @@ public class IonToParquet extends AbstractAvroConverter implements RunnableTask<
 
     static {
         ParquetTools.handleLogger();
+
+        // We initialize snappy in a static initializer block, so it is done when the plugin is loaded by the plugin registry,
+        // and not at when it is executed by the Worker to prevent issues with Java Security that prevent writing on /tmp.
+        ParquetTools.initSnappy();
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")

--- a/src/main/java/io/kestra/plugin/serdes/parquet/ParquetToIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/parquet/ParquetToIon.java
@@ -74,6 +74,10 @@ public class ParquetToIon extends Task implements RunnableTask<ParquetToIon.Outp
 
     static {
         ParquetTools.handleLogger();
+
+        // We initialize snappy in a static initializer block, so it is done when the plugin is loaded by the plugin registry,
+        // and not at when it is executed by the Worker to prevent issues with Java Security that prevent writing on /tmp.
+        ParquetTools.initSnappy();
     }
 
     public Output run(RunContext runContext) throws Exception {

--- a/src/main/java/io/kestra/plugin/serdes/parquet/ParquetTools.java
+++ b/src/main/java/io/kestra/plugin/serdes/parquet/ParquetTools.java
@@ -2,6 +2,9 @@ package io.kestra.plugin.serdes.parquet;
 
 import ch.qos.logback.classic.LoggerContext;
 import org.slf4j.LoggerFactory;
+import org.xerial.snappy.Snappy;
+
+import java.io.IOException;
 
 public abstract class ParquetTools {
     static void handleLogger() {
@@ -15,5 +18,17 @@ public abstract class ParquetTools {
             .forEach(
                 logger -> logger.setLevel(ch.qos.logback.classic.Level.ERROR)
             );
+    }
+
+    /**
+     * This will init snappy by compressing a small string.
+     * It should be done once and will load the native library.
+     */
+    static void initSnappy() {
+        try {
+            Snappy.compress("init");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
Which causes issue when enabling Java Security as write out of the working directory will be prevented.