### PR TITLE
feat(markdown): introduce MarkdownToHtml and MarkdownToText

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,8 @@ dependencies {
     api group: 'org.json', name: 'json', version: '20250517'
 
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-ion' // for IonFactory
+
+    implementation "org.commonmark:commonmark:0.26.0" // for Markdown
 }
 
 

--- a/src/main/java/io/kestra/plugin/serdes/markdown/MarkdownToHtml.java
+++ b/src/main/java/io/kestra/plugin/serdes/markdown/MarkdownToHtml.java
@@ -1,0 +1,103 @@
+package io.kestra.plugin.serdes.markdown;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.executions.metrics.Counter;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Convert a Markdown file into an HTML file.",
+    description = "Turns Markdown into HTML syntax suitable for embedding into HTML contexts like email templates."
+)
+@Plugin(
+    examples = {
+        @Example(
+            full = true,
+            title = "Convert Markdown text into HTML syntax.",
+            code = """
+                id: markdown_to_html
+                namespace: company.team
+
+                tasks:
+                  - id: output_markdown
+                    type: io.kestra.plugin.core.output.OutputValues
+                    values:
+                      markdown: |
+                        # Hello
+                        This is **bold** and [link](https://kestra.io)
+
+                  - id: write_markdown
+                    type: io.kestra.plugin.core.storage.Write
+                    content: "{{ outputs.output_markdown.values.markdown }}"
+                    extension: ".md"
+
+                  - id: to_html
+                    type: io.kestra.plugin.serdes.markdown.MarkdownToHtml
+                    from: "{{ outputs.write_markdown.uri }}"
+                """
+        )
+    }
+)
+public class MarkdownToHtml extends Task implements RunnableTask<MarkdownToHtml.Output> {
+    @NotNull
+    @Schema(title = "Source file URI")
+    @PluginProperty(internalStorageURI = true)
+    private Property<String> from;
+
+    @Builder.Default
+    @Schema(title = "Charset to use for input/output", description = "Default is UTF-8.")
+    private final Property<String> charset = Property.ofValue(StandardCharsets.UTF_8.name());
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        var rFrom = new URI(runContext.render(this.from).as(String.class).orElseThrow());
+        var rCharset = Charset.forName(runContext.render(this.charset).as(String.class).orElse(StandardCharsets.UTF_8.name()));
+
+        var tempFile = runContext.workingDir().createTempFile(".html").toFile();
+
+        try (var inputStream = runContext.storage().getFile(rFrom);
+             var reader = new InputStreamReader(inputStream, rCharset);
+             var writer = new OutputStreamWriter(new FileOutputStream(tempFile), rCharset)) {
+
+            var parser = Parser.builder().build();
+            var document = parser.parseReader(reader);
+            var renderer = HtmlRenderer.builder().escapeHtml(false).build();
+
+            var html = renderer.render(document);
+            writer.write(html);
+
+            runContext.metric(Counter.of("bytes", html.length()));
+        }
+
+        return Output.builder().uri(runContext.storage().putFile(tempFile)).build();
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(title = "URI of the generated HTML file")
+        private final URI uri;
+    }
+}

--- a/src/main/java/io/kestra/plugin/serdes/markdown/MarkdownToText.java
+++ b/src/main/java/io/kestra/plugin/serdes/markdown/MarkdownToText.java
@@ -1,0 +1,163 @@
+package io.kestra.plugin.serdes.markdown;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.executions.metrics.Counter;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.models.tasks.Task;
+import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.commonmark.node.*;
+import org.commonmark.parser.Parser;
+
+import java.io.BufferedReader;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Convert a Markdown file into plain text.",
+    description = "Removes Markdown formatting and outputs plain text, using CommonMark parser."
+)
+@Plugin(
+    examples = {
+        @Example(
+            full = true,
+            title = "Convert Markdown text into plain text.",
+            code = """
+                id: markdown_to_text
+                namespace: company.team
+
+                tasks:
+                  - id: output_markdown
+                    type: io.kestra.plugin.core.output.OutputValues
+                    values:
+                      markdown: |
+                        ## Berlin News
+                        - **Cirque du Soleil** announces show
+                        - Read more at [reuters.com](https://reuters.com)
+
+                  - id: write_markdown
+                    type: io.kestra.plugin.core.storage.Write
+                    content: "{{ outputs.output_markdown.values.markdown }}"
+                    extension: ".md"
+
+                  - id: to_text
+                    type: io.kestra.plugin.serdes.markdown.MarkdownToText
+                    from: "{{ outputs.write_markdown.uri }}"
+                """
+        )
+    }
+)
+public class MarkdownToText extends Task implements RunnableTask<MarkdownToText.Output> {
+    @NotNull
+    @Schema(title = "Source file URI")
+    @PluginProperty(internalStorageURI = true)
+    private Property<String> from;
+
+    @Builder.Default
+    @Schema(title = "Charset to use for input/output", description = "Default is UTF-8.")
+    private final Property<String> charset = Property.ofValue(StandardCharsets.UTF_8.name());
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        var rFrom = new URI(runContext.render(this.from).as(String.class).orElseThrow());
+        var rCharset = Charset.forName(runContext.render(this.charset).as(String.class).orElse(StandardCharsets.UTF_8.name()));
+
+        var tempFile = runContext.workingDir().createTempFile(".txt").toFile();
+
+        String markdown;
+        try (var inputStream = runContext.storage().getFile(rFrom);
+             var reader = new BufferedReader(new InputStreamReader(inputStream, rCharset))) {
+
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line).append("\n");
+            }
+            markdown = sb.toString();
+        }
+
+        String plainText = toPlainText(markdown);
+
+        try (var writer = new OutputStreamWriter(new FileOutputStream(tempFile), rCharset)) {
+            writer.write(plainText);
+        }
+
+        runContext.metric(Counter.of("bytes", plainText.length()));
+
+        return Output.builder().uri(runContext.storage().putFile(tempFile)).build();
+    }
+
+    private String toPlainText(String markdown) {
+        if (markdown == null) return "";
+
+        Parser parser = Parser.builder().build();
+        Node document = parser.parse(markdown);
+        StringBuilder sb = new StringBuilder();
+
+        document.accept(new AbstractVisitor() {
+            @Override
+            public void visit(Text text) {
+                sb.append(text.getLiteral());
+            }
+
+            @Override
+            public void visit(SoftLineBreak softLineBreak) {
+                sb.append(" ");
+            }
+
+            @Override
+            public void visit(HardLineBreak hardLineBreak) {
+                sb.append("\n");
+            }
+
+            @Override
+            public void visit(Link link) {
+                // keep the text but ignore the URL
+                visitChildren(link);
+            }
+
+            @Override
+            public void visit(Paragraph paragraph) {
+                visitChildren(paragraph);
+                sb.append("\n");
+            }
+
+            @Override
+            public void visit(Heading heading) {
+                visitChildren(heading);
+                sb.append("\n");
+            }
+
+            @Override
+            public void visit(ListItem listItem) {
+                sb.append("- ");
+                visitChildren(listItem);
+                sb.append("\n");
+            }
+        });
+
+        return sb.toString().trim();
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(title = "URI of the generated plain text file")
+        private final URI uri;
+    }
+}

--- a/src/main/resources/icons/io.kestra.plugin.serdes.markdown.svg
+++ b/src/main/resources/icons/io.kestra.plugin.serdes.markdown.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="208" height="128" viewBox="0 0 208 128">
+    <rect width="198" height="118" x="5" y="5" ry="10" stroke="#000" stroke-width="10" fill="none"/>
+    <path d="M30 98V30h20l20 25 20-25h20v68H90V59L70 84 50 59v39zm125 0l-30-33h20V30h20v35h20z" fill="currentColor"/>
+</svg>

--- a/src/test/java/io/kestra/plugin/serdes/markdown/MarkdownToHtmlTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/markdown/MarkdownToHtmlTest.java
@@ -1,0 +1,89 @@
+package io.kestra.plugin.serdes.markdown;
+
+import com.google.common.collect.ImmutableMap;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.utils.IdUtils;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@KestraTest
+public class MarkdownToHtmlTest {
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Inject
+    private StorageInterface storageInterface;
+
+    @Test
+    void should_convert_markdown_to_html() throws Exception {
+        // Given
+        String markdown = """
+            # Hello Kestra
+
+            This is **bold** and *italic* text with a [link](https://kestra.io)
+
+            - Item 1
+            - Item 2
+            """;
+
+        var runContext = getRunContext(markdown);
+
+        var task = MarkdownToHtml.builder()
+            .from(Property.ofExpression("{{ file }}"))
+            .build();
+
+        // When
+        var output = task.run(runContext);
+
+        // Then
+        assertThat("Result file should exist", storageInterface.exists(MAIN_TENANT, null, output.getUri()), is(true));
+
+        try (InputStream resultStream = storageInterface.get(MAIN_TENANT, null, output.getUri())) {
+            String html = new String(resultStream.readAllBytes(), StandardCharsets.UTF_8);
+
+            assertThat(html, containsString("<h1>Hello Kestra</h1>"));
+            assertThat(html, containsString("<strong>bold</strong>"));
+            assertThat(html, containsString("<em>italic</em>"));
+            assertThat(html, containsString("<a href=\"https://kestra.io\">link</a>"));
+            assertThat(html, containsString("<li>Item 1</li>"));
+        } catch (Exception e) {
+            fail("Unable to read output file: " + e.getMessage());
+        }
+    }
+
+    private RunContext getRunContext(String markdownContent) {
+        Map<String, String> kestraVars = new HashMap<>();
+        URI filePath;
+        try {
+            filePath = storageInterface.put(
+                MAIN_TENANT,
+                null,
+                URI.create("/" + IdUtils.create() + ".md"),
+                new ByteArrayInputStream(markdownContent.getBytes(StandardCharsets.UTF_8))
+            );
+            kestraVars.put("file", filePath.toString());
+        } catch (Exception e) {
+            fail("Unable to prepare input file: " + e.getMessage());
+            return null;
+        }
+        return runContextFactory.of(ImmutableMap.copyOf(kestraVars));
+    }
+}

--- a/src/test/java/io/kestra/plugin/serdes/markdown/MarkdownToTextTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/markdown/MarkdownToTextTest.java
@@ -1,0 +1,115 @@
+package io.kestra.plugin.serdes.markdown;
+
+import com.google.common.collect.ImmutableMap;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.utils.IdUtils;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.kestra.core.tenant.TenantService.MAIN_TENANT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@KestraTest
+public class MarkdownToTextTest {
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Inject
+    private StorageInterface storageInterface;
+
+    @Test
+    void should_convert_markdown_to_plain_text() throws Exception {
+        // Given
+        String markdown = """
+            # Berlin News
+
+            **Cirque du Soleil** announces new show in *Berlin*.
+
+            Read more at [reuters.com](https://reuters.com)
+
+            - Item A
+            - Item B
+            """;
+
+        var runContext = getRunContext(markdown);
+
+        var task = MarkdownToText.builder()
+            .from(Property.ofExpression("{{ file }}"))
+            .build();
+
+        // When
+        var output = task.run(runContext);
+
+        // Then
+        assertThat("Result file should exist", storageInterface.exists(MAIN_TENANT, null, output.getUri()), is(true));
+
+        try (InputStream resultStream = storageInterface.get(MAIN_TENANT, null, output.getUri())) {
+            String text = new String(resultStream.readAllBytes(), StandardCharsets.UTF_8);
+
+            // check expected content
+            assertThat(text, containsString("Berlin News"));
+            assertThat(text, containsString("Cirque du Soleil announces new show in Berlin."));
+            assertThat(text, containsString("Read more at reuters.com"));
+            assertThat(text, containsString("- Item A"));
+            assertThat(text, containsString("- Item B"));
+
+            // check no markdown remains
+            assertThat(text, not(containsString("**")));
+            assertThat(text, not(containsString("*Berlin*")));
+            assertThat(text, not(containsString("[")));
+            assertThat(text, not(containsString("](")));
+        } catch (Exception e) {
+            fail("Unable to read output file: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void should_handle_empty_markdown() throws Exception {
+        var runContext = getRunContext("");
+
+        var task = MarkdownToText.builder()
+            .from(Property.ofExpression("{{ file }}"))
+            .build();
+
+        var output = task.run(runContext);
+
+        assertThat(storageInterface.exists(MAIN_TENANT, null, output.getUri()), is(true));
+
+        try (InputStream resultStream = storageInterface.get(MAIN_TENANT, null, output.getUri())) {
+            String text = new String(resultStream.readAllBytes(), StandardCharsets.UTF_8);
+            assertThat(text.trim(), is(""));
+        }
+    }
+
+    private RunContext getRunContext(String markdownContent) {
+        Map<String, String> kestraVars = new HashMap<>();
+        URI filePath;
+        try {
+            filePath = storageInterface.put(
+                MAIN_TENANT,
+                null,
+                URI.create("/" + IdUtils.create() + ".md"),
+                new ByteArrayInputStream(markdownContent.getBytes(StandardCharsets.UTF_8))
+            );
+            kestraVars.put("file", filePath.toString());
+        } catch (Exception e) {
+            fail("Unable to prepare input file: " + e.getMessage());
+            return null;
+        }
+        return runContextFactory.of(ImmutableMap.copyOf(kestraVars));
+    }
+}


### PR DESCRIPTION
closes #187 

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

**Example flow #1:** 

```yaml
id: markdown_to_html
namespace: company.team

tasks:
  - id: output_markdown
    type: io.kestra.plugin.core.output.OutputValues
    values:
      markdown: |
        # Hello
        This is **bold** and [link](https://kestra.io)

  - id: write_markdown
    type: io.kestra.plugin.core.storage.Write
    content: "{{ outputs.output_markdown.values.markdown }}"
    extension: ".md"

  - id: to_html
    type: io.kestra.plugin.serdes.markdown.MarkdownToHtml
    from: "{{ outputs.write_markdown.uri }}"
```

Results:

<img width="3037" height="455" alt="image" src="https://github.com/user-attachments/assets/7e3234b4-9a39-4385-b031-873c91cf5a66" />

Outputs:

<img width="3177" height="682" alt="image" src="https://github.com/user-attachments/assets/9d228b81-2f77-4ea0-b6e1-1a449506e6a7" />

**Example flow #2:**

```yaml
id: markdown_to_text
namespace: company.team

tasks:
  - id: output_markdown
    type: io.kestra.plugin.core.output.OutputValues
    values:
      markdown: |
        ## Berlin News
        - **Cirque du Soleil** announces show
        - Read more at [reuters.com](https://reuters.com)

  - id: write_markdown
    type: io.kestra.plugin.core.storage.Write
    content: "{{ outputs.output_markdown.values.markdown }}"
    extension: ".md"

  - id: to_text
    type: io.kestra.plugin.serdes.markdown.MarkdownToText
    from: "{{ outputs.write_markdown.uri }}"
```

Results:

<img width="3022" height="450" alt="image" src="https://github.com/user-attachments/assets/beeb5c85-a841-493c-a64f-173151394bd3" />

Outputs:

<img width="3161" height="686" alt="image" src="https://github.com/user-attachments/assets/980ee82d-198c-4641-bfa8-a2df49086e4a" />

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).
