### PR TITLE
fix: replace `protobuf `with `infer_ion_parquet` to pass sanity checks

### DIFF
--- a/src/test/resources/sanity-checks/all_serdes.yaml
+++ b/src/test/resources/sanity-checks/all_serdes.yaml
@@ -9,7 +9,7 @@ tasks:
       - csv
       - excel
       - infer_ion_avro
-      - protobuf
+      - infer_ion_parquet
     tasks:
       - id: subflow
         type: io.kestra.plugin.core.flow.Subflow


### PR DESCRIPTION
The sanity check is failing because the flow name and the file name are different, making it even like others

<img width="1069" height="134" alt="Screenshot 2025-12-09 at 12 04 32 PM" src="https://github.com/user-attachments/assets/008a91f4-cb7c-4e7e-bfaa-08fdea53b019" />
