### PR TITLE
chore: shrink final shadow JAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,26 +62,37 @@ dependencies {
     implementation "com.google.protobuf:protobuf-java:4.33.2"
     implementation "com.google.protobuf:protobuf-java-util:4.33.2"
 
-    api 'de.siegmar:fastcsv:4.1.0'
-    api ('org.apache.avro:avro:1.12.1') {
+    implementation 'de.siegmar:fastcsv:4.1.0'
+    implementation ('org.apache.avro:avro:1.12.1') {
         exclude group: 'com.fasterxml.jackson.core'
     }
-    api group: 'org.apache.parquet', name: 'parquet-avro', version: '1.15.2'
-    api group: 'org.apache.poi', name: 'poi', version: '5.5.1'
-    api group: 'org.apache.poi', name: 'poi-ooxml', version: '5.5.1'
-    api group: 'com.github.pjfanning', name: 'excel-streaming-reader', version: '5.2.0'
+    implementation group: 'org.apache.parquet', name: 'parquet-avro', version: '1.15.2'
+    implementation group: 'org.apache.poi', name: 'poi', version: '5.5.1'
+    implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.5.1'
+    implementation group: 'com.github.pjfanning', name: 'excel-streaming-reader', version: '5.2.0'
     implementation("com.amazon.ion:ion-java:1.11.11")
-    api (group: 'org.apache.hadoop', name: 'hadoop-client', version: '3.4.2') {
-        exclude group: 'org.slf4j'
-        exclude group: 'com.fasterxml.jackson.core'
+    implementation("org.apache.hadoop:hadoop-common:3.4.2") {
+        exclude group: "org.slf4j"
+        exclude group: "com.fasterxml.jackson.core"
     }
-    api group: 'org.json', name: 'json', version: '20251224'
+    implementation("org.apache.hadoop:hadoop-auth:3.4.2") {
+        exclude group: "org.slf4j"
+        exclude group: "com.fasterxml.jackson.core"
+    }
+    implementation("org.apache.hadoop:hadoop-mapreduce-client-core:3.4.2") {
+        exclude group: "org.slf4j"
+        exclude group: "com.fasterxml.jackson.core"
+    }
+    implementation group: 'org.json', name: 'json', version: '20251224'
 
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-ion' // for IonFactory
 
     implementation "org.commonmark:commonmark:0.27.0" // for Markdown
 }
 
+configurations.configureEach {
+    exclude group: "org.apache.hadoop", module: "hadoop-client"
+}
 
 /**********************************************************************************************************************\
  * Test
@@ -223,6 +234,14 @@ jar {
 shadowJar {
     archiveClassifier.set(null)
     mergeServiceFiles()
+
+    dependencies {
+        exclude(dependency("io.netty:netty-.*:.*"))
+        exclude(dependency("com.fasterxml.jackson.core:jackson-.*:.*"))
+        exclude(dependency("com.fasterxml.jackson.datatype:jackson-.*:.*"))
+        exclude(dependency("org.slf4j:slf4j-api:.*"))
+        exclude(dependency("ch.qos.logback:logback-classic:.*"))
+    }
 }
 
 /**********************************************************************************************************************\


### PR DESCRIPTION
fixes https://github.com/kestra-io/kestra-ee/issues/6414

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?

Removed hadoop-client in profit of less heavy minimal needed hadoop libs.
Excluded deps already got from the core.

About 16.81 % (19 MB) saved :tada: 

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

Flow

```yaml
id: ion_to_parquet
namespace: company.team

tasks:
  - id: download_csv
    type: io.kestra.plugin.core.http.Download
    description: salaries of data professionals from 2020 to 2023 (source ai-jobs.net)
    uri: https://huggingface.co/datasets/kestra/datasets/raw/main/csv/salaries.csv

  - id: avg_salary_by_job_title
    type: io.kestra.plugin.jdbc.duckdb.Query
    inputFiles:
      data.csv: "{{ outputs.download_csv.uri }}"
    sql: |
      SELECT
        job_title,
        ROUND(AVG(salary),2) AS avg_salary
      FROM read_csv_auto('{{ workingDir }}/data.csv', header=True)
      GROUP BY job_title
      HAVING COUNT(job_title) > 10
      ORDER BY avg_salary DESC;
    store: true

  - id: result
    type: io.kestra.plugin.serdes.parquet.IonToParquet
    from: "{{ outputs.avg_salary_by_job_title.uri }}"
    schema: |
      {
        "type": "record",
        "name": "Salary",
        "namespace": "com.example.salary",
        "fields": [
          {"name": "job_title", "type": "string"},
          {"name": "avg_salary", "type": "double"}
        ]
      }
```

Results:

<img width="3013" height="461" alt="image" src="https://github.com/user-attachments/assets/96201d0c-d161-43f5-954d-b02b0f9bda76" />

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Every time you use `runContext.metric(...)` you have to add a `@Metric` ([see this doc](https://kestra.io/docs/plugin-developer-guide/document#document-the-plugin-metrics))
- [ ] Docs don't support to have both tasks/triggers in the root package (e.g. `io.kestra.plugin.kubernetes`) and in a sub package (e.g. `io.kestra.plugin.kubernetes.kubectl`), whether it's: all tasks/triggers in the root package OR only tasks/triggers in sub packages.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.
- [ ] Update the existing `index.yaml` for the main plugin, and for each new subpackage add a metadata file named exactly after the subpackage (e.g. `s3.yaml` for `io.kestra.plugin.aws.s3`) under `src/main/resources/metadata/`, following the same schema.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (to be set executable with `chmod +x setup-unit.sh`) (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`). If needed, create an executable (`chmod +x cleanup-unit.sh`) `cleanup-unit.sh` to remove the potential costly resources (tables, datasets, etc).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).