### PR TITLE
Add small hint for "SerDes" to Serialization plugin

### DIFF
--- a/src/main/resources/metadata/index.yaml
+++ b/src/main/resources/metadata/index.yaml
@@ -1,7 +1,7 @@
 group: io.kestra.plugin.serdes
 name: "serdes"
 title: "Serialization"
-description: "Tasks that convert data between common formats for Kestra workflows."
+description: "Tasks that convert data (SerDes) between common formats for Kestra workflows."
 body: "Use format-specific tasks to transform files among JSON, CSV, Avro, Parquet, Excel, Protobuf, XML, Markdown, and YAML (via Ion), with options for schema validation, bad-line handling, and output destinations."
 videos: []
 createdBy: "Kestra Core Team"


### PR DESCRIPTION
### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->
I added a small hint to the description to help users know that the serialization plugin falls under "SerDes". This was not obvious to me, particularly when working with the flow code editor and autocompletion.
