### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.8.4-SNAPSHOT
-kestraVersion=1.2.3
+kestraVersion=1.3.19

--- a/src/main/java/io/kestra/plugin/serdes/avro/AbstractAvroConverter.java
+++ b/src/main/java/io/kestra/plugin/serdes/avro/AbstractAvroConverter.java
@@ -1,7 +1,7 @@
 package io.kestra.plugin.serdes.avro;
 
 import java.io.IOException;
-import java.io.Reader;
+import java.io.InputStream;
 import java.time.ZoneId;
 import java.util.*;
 import java.util.function.Function;
@@ -150,7 +150,7 @@ public abstract class AbstractAvroConverter extends Task {
     @PluginProperty(group = "advanced")
     protected final Property<OnBadLines> onBadLines = Property.ofValue(OnBadLines.ERROR);
 
-    protected <E extends Exception> Long convert(Reader inputStream, org.apache.avro.Schema schema, Rethrow.ConsumerChecked<GenericData.Record, E> consumer, RunContext runContext)
+    protected <E extends Exception> Long convert(InputStream inputStream, org.apache.avro.Schema schema, Rethrow.ConsumerChecked<GenericData.Record, E> consumer, RunContext runContext)
         throws IOException, IllegalVariableEvaluationException {
         OnBadLines rOnBadLines = runContext.render(this.onBadLines).as(OnBadLines.class).orElse(OnBadLines.ERROR);
         AvroConverter converter = AvroConverter.builder()

--- a/src/main/java/io/kestra/plugin/serdes/avro/AvroToIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/avro/AvroToIon.java
@@ -95,7 +95,7 @@ public class AvroToIon extends Task implements RunnableTask<AvroToIon.Output> {
         try (
             InputStream in = runContext.storage().getFile(rFrom);
             DataFileStream<GenericRecord> dataFileStream = new DataFileStream<>(in, datumReader);
-            BufferedWriter output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)
+            BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)
         ) {
             org.apache.avro.Schema avroSchema = dataFileStream.getSchema();
 

--- a/src/main/java/io/kestra/plugin/serdes/avro/InferAvroSchemaFromIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/avro/InferAvroSchemaFromIon.java
@@ -1,9 +1,8 @@
 package io.kestra.plugin.serdes.avro;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
-import java.io.BufferedReader;
 import java.io.FileOutputStream;
-import java.io.InputStreamReader;
 import java.net.URI;
 
 import io.kestra.core.models.annotations.Plugin;
@@ -59,7 +58,7 @@ public class InferAvroSchemaFromIon extends Task implements RunnableTask<InferAv
         var from = new URI(runContext.render(this.from).as(String.class).orElseThrow());
 
         try (
-            var inputStream = new BufferedReader(new InputStreamReader(runContext.storage().getFile(from)), FileSerde.BUFFER_SIZE);
+            var inputStream = new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE);
             var output = new BufferedOutputStream(new FileOutputStream(tempAvroSchemaFile), FileSerde.BUFFER_SIZE);
         ) {
             new InferAvroSchema(

--- a/src/main/java/io/kestra/plugin/serdes/avro/IonToAvro.java
+++ b/src/main/java/io/kestra/plugin/serdes/avro/IonToAvro.java
@@ -140,7 +140,7 @@ public class IonToAvro extends AbstractAvroConverter implements RunnableTask<Ion
         var schemaParser = new org.apache.avro.Schema.Parser();
         org.apache.avro.Schema schema;
         if (this.schema == null) {
-            try (var inputStreamForInfer = new InputStreamReader(runContext.storage().getFile(rFrom))) {
+            try (var inputStreamForInfer = runContext.storage().getFile(rFrom)) {
                 var schemaOutputStream = new ByteArrayOutputStream();
                 new InferAvroSchema(
                     runContext.render(this.getNumberOfRowsToScan()).as(Integer.class).orElse(100)
@@ -160,7 +160,7 @@ public class IonToAvro extends AbstractAvroConverter implements RunnableTask<Ion
         DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(schema, AvroConverter.genericData());
 
         try (
-            Reader inputStream = new BufferedReader(new InputStreamReader(runContext.storage().getFile(rFrom)), FileSerde.BUFFER_SIZE);
+            InputStream inputStream = new BufferedInputStream(runContext.storage().getFile(rFrom), FileSerde.BUFFER_SIZE);
             OutputStream output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE);
             DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<>(datumWriter);
             DataFileWriter<GenericRecord> schemaDataFileWriter = dataFileWriter.create(schema, output)

--- a/src/main/java/io/kestra/plugin/serdes/avro/infer/InferAvroSchema.java
+++ b/src/main/java/io/kestra/plugin/serdes/avro/infer/InferAvroSchema.java
@@ -1,8 +1,8 @@
 package io.kestra.plugin.serdes.avro.infer;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.Reader;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.*;
@@ -46,7 +46,7 @@ public class InferAvroSchema {
      * @param output where the resulting Avro schema will be written
      * @throws IllegalStateException if the input stream is empty or contains no valid records
      */
-    public void inferAvroSchemaFromIon(Reader inputStream, OutputStream output) {
+    public void inferAvroSchemaFromIon(InputStream inputStream, OutputStream output) {
         Mono<Schema> inferedSchema = null;
         try {
             inferedSchema = FileSerde.readAll(inputStream)

--- a/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
@@ -165,7 +165,7 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
                 FileSerde.BUFFER_SIZE
             );
             CsvReader<CsvRecord> csvReader = this.csvReader(reader, runContext);
-            Writer output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)
+            OutputStream output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)
         ) {
             var rHeaderValue = runContext.render(header).as(Boolean.class).orElseThrow();
             var rSkipRowsValue = runContext.render(this.skipRows).as(Integer.class).orElseThrow();

--- a/src/main/java/io/kestra/plugin/serdes/csv/IonToCsv.java
+++ b/src/main/java/io/kestra/plugin/serdes/csv/IonToCsv.java
@@ -185,13 +185,13 @@ public class IonToCsv extends AbstractTextWriter implements RunnableTask<IonToCs
         this.init(runContext);
 
         try (
-            Reader inputStream = new BufferedReader(new InputStreamReader(runContext.storage().getFile(rFrom)), FileSerde.BUFFER_SIZE);
+            InputStream is = new BufferedInputStream(runContext.storage().getFile(rFrom), FileSerde.BUFFER_SIZE);
             Writer fileWriter = new BufferedWriter(new FileWriter(tempFile, Charset.forName(runContext.render(this.charset).as(String.class).orElseThrow())), FileSerde.BUFFER_SIZE);
             CsvWriter csvWriter = this.csvWriter(fileWriter, runContext)
         ) {
 
             var rHeaderValue = runContext.render(header).as(Boolean.class).orElseThrow();
-            Flux<Object> flowable = FileSerde.readAll(inputStream)
+            Flux<Object> flowable = FileSerde.readAll(is)
                 .doOnNext(new Consumer<>() {
                     private boolean first = false;
 

--- a/src/main/java/io/kestra/plugin/serdes/excel/ExcelToIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/excel/ExcelToIon.java
@@ -1,8 +1,8 @@
 package io.kestra.plugin.serdes.excel;
 
-import java.io.BufferedWriter;
+import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.time.ZoneId;
@@ -332,7 +332,7 @@ public class ExcelToIon extends Task implements RunnableTask<ExcelToIon.Output> 
 
     private File store(RunContext runContext, Collection<Object> values) throws IOException {
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
-        try (var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)) {
+        try (var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
             var flux = Flux.fromIterable(values);
             FileSerde.writeAll(output, flux).block();
         }

--- a/src/main/java/io/kestra/plugin/serdes/json/JsonToIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/json/JsonToIon.java
@@ -2,7 +2,6 @@ package io.kestra.plugin.serdes.json;
 
 import java.io.*;
 import java.net.URI;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.TimeZone;
@@ -133,11 +132,11 @@ public class JsonToIon extends Task implements RunnableTask<JsonToIon.Output> {
 
         try (
             BufferedReader input = new BufferedReader(new InputStreamReader(runContext.storage().getFile(from), renderedCharset), FileSerde.BUFFER_SIZE);
-            Writer writer = new BufferedWriter(new FileWriter(tempFile, Charset.forName(renderedCharset)), FileSerde.BUFFER_SIZE)
+            OutputStream output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)
         ) {
             Flux<Object> flowable = Flux
                 .create(this.nextRow(input, renderedNewLine), FluxSink.OverflowStrategy.BUFFER);
-            Mono<Long> count = FileSerde.writeAll(writer, flowable);
+            Mono<Long> count = FileSerde.writeAll(output, flowable);
 
             // metrics & finalize
             Long lineCount = count.block();

--- a/src/main/java/io/kestra/plugin/serdes/parquet/IonToParquet.java
+++ b/src/main/java/io/kestra/plugin/serdes/parquet/IonToParquet.java
@@ -23,6 +23,7 @@ import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.serdes.avro.AbstractAvroConverter;
 import io.kestra.plugin.serdes.avro.AvroConverter;
@@ -164,7 +165,7 @@ public class IonToParquet extends AbstractAvroConverter implements RunnableTask<
         var schemaParser = new org.apache.avro.Schema.Parser();
         org.apache.avro.Schema schema;
         if (this.schema == null) {
-            try (var inputStreamForInfer = new InputStreamReader(runContext.storage().getFile(from))) {
+            try (var inputStreamForInfer = runContext.storage().getFile(from)) {
                 var schemaOutputStream = new ByteArrayOutputStream();
                 new InferAvroSchema(
                     runContext.render(this.getNumberOfRowsToScan()).as(Integer.class).orElse(100)
@@ -193,7 +194,7 @@ public class IonToParquet extends AbstractAvroConverter implements RunnableTask<
         // convert
         try (
             org.apache.parquet.hadoop.ParquetWriter<GenericData.Record> writer = parquetWriterBuilder.build();
-            Reader inputStream = new InputStreamReader(runContext.storage().getFile(from))
+            InputStream inputStream = new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE)
         ) {
             Long lineCount = this.convert(inputStream, schema, writer::write, runContext);
 

--- a/src/main/java/io/kestra/plugin/serdes/parquet/ParquetToIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/parquet/ParquetToIon.java
@@ -104,7 +104,7 @@ public class ParquetToIon extends Task implements RunnableTask<ParquetToIon.Outp
 
         try (
             org.apache.parquet.hadoop.ParquetReader<GenericRecord> parquetReader = parquetReaderBuilder.build();
-            Writer output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)
+            OutputStream output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)
         ) {
 
             Flux<Object> flowable = Flux

--- a/src/main/java/io/kestra/plugin/serdes/protobuf/ProtobufToIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/protobuf/ProtobufToIon.java
@@ -2,7 +2,6 @@ package io.kestra.plugin.serdes.protobuf;
 
 import java.io.*;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.TimeZone;
 import java.util.function.Consumer;
@@ -145,8 +144,8 @@ public class ProtobufToIon extends Task implements RunnableTask<ProtobufToIon.Ou
 
         try (
             InputStream inputStream = runContext.storage().getFile(rFrom);
-            Writer writer = new BufferedWriter(
-                new FileWriter(tempFile, StandardCharsets.UTF_8),
+            OutputStream writer = new BufferedOutputStream(
+                new FileOutputStream(tempFile),
                 FileSerde.BUFFER_SIZE
             )
         ) {

--- a/src/main/java/io/kestra/plugin/serdes/xml/IonToXml.java
+++ b/src/main/java/io/kestra/plugin/serdes/xml/IonToXml.java
@@ -123,9 +123,7 @@ public class IonToXml extends Task implements RunnableTask<IonToXml.Output> {
 
         try (
             Writer outfile = new BufferedWriter(new FileWriter(tempFile, Charset.forName(runContext.render(charset).as(String.class).orElseThrow())), FileSerde.BUFFER_SIZE);
-            Reader inputStream = new BufferedReader(
-                new InputStreamReader(runContext.storage().getFile(from), Charset.forName(runContext.render(charset).as(String.class).orElseThrow())), FileSerde.BUFFER_SIZE
-            )
+            InputStream is = new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE)
         ) {
             XmlMapper mapper = new XmlMapper();
 
@@ -141,7 +139,7 @@ public class IonToXml extends Task implements RunnableTask<IonToXml.Output> {
                 .withRootName(runContext.render(this.rootName).as(String.class).orElseThrow())
                 .withFeatures(ToXmlGenerator.Feature.WRITE_XML_DECLARATION);
 
-            List<Object> list = FileSerde.readAll(inputStream).collectList().block();
+            List<Object> list = FileSerde.readAll(is).collectList().block();
             if (list != null) {
                 outfile.write(objectWriter.writeValueAsString(list));
                 runContext.metric(Counter.of("records", list.size()));

--- a/src/main/java/io/kestra/plugin/serdes/yaml/IonToYaml.java
+++ b/src/main/java/io/kestra/plugin/serdes/yaml/IonToYaml.java
@@ -89,11 +89,11 @@ public class IonToYaml extends Task implements RunnableTask<IonToYaml.Output> {
         long count = 0;
 
         try (
-            BufferedReader reader = new BufferedReader(new InputStreamReader(runContext.storage().getFile(rFrom)), FileSerde.BUFFER_SIZE);
+            InputStream is = new BufferedInputStream(runContext.storage().getFile(rFrom), FileSerde.BUFFER_SIZE);
             BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile, rCharset), FileSerde.BUFFER_SIZE)
         ) {
 
-            Flux<Object> flux = FileSerde.readAll(reader);
+            Flux<Object> flux = FileSerde.readAll(is);
             var it = flux.toIterable().iterator();
 
             if (it.hasNext()) {

--- a/src/test/java/io/kestra/plugin/serdes/avro/infer/InferAvroSchemaFromIonTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/avro/infer/InferAvroSchemaFromIonTest.java
@@ -3,7 +3,6 @@ package io.kestra.plugin.serdes.avro.infer;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
 
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -171,7 +170,7 @@ public class InferAvroSchemaFromIonTest {
 
         // when
         new InferAvroSchema().inferAvroSchemaFromIon(
-            new InputStreamReader(new ByteArrayInputStream(input.getBytes())),
+            new ByteArrayInputStream(input.getBytes()),
             output
         );
 

--- a/src/test/java/io/kestra/plugin/serdes/csv/CsvToIonWriterTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/csv/CsvToIonWriterTest.java
@@ -102,7 +102,7 @@ class CsvToIonWriterTest {
 
         List<Object> rows;
         try (var in = storageInterface.get(TenantService.MAIN_TENANT, null, out.getUri())) {
-            rows = FileSerde.readAll(new InputStreamReader(in, StandardCharsets.UTF_8)).collectList().block();
+            rows = FileSerde.readAll(in).collectList().block();
         }
 
         assertThat(rows, is(notNullValue()));

--- a/src/test/java/io/kestra/plugin/serdes/parquet/IonToParquetTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/parquet/IonToParquetTest.java
@@ -85,7 +85,7 @@ class IonToParquetTest {
             ParquetToIon.Output readerOutput = reader.run(TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of()));
 
             List<Map<String, Object>> result = new ArrayList<>();
-            FileSerde.reader(new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, readerOutput.getUri()))), r -> result.add((Map<String, Object>) r));
+            FileSerde.read(storageInterface.get(TenantService.MAIN_TENANT, null, readerOutput.getUri()), r -> result.add((Map<String, Object>) r));
 
             assertThat(result.size(), is(1));
             assertThat(result.get(0).get("String"), is("string"));
@@ -138,7 +138,7 @@ class IonToParquetTest {
             ParquetToIon.Output readerOutput = reader.run(TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of()));
 
             List<Map<String, Object>> result = new ArrayList<>();
-            FileSerde.reader(new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, readerOutput.getUri()))), r -> result.add((Map<String, Object>) r));
+            FileSerde.read(storageInterface.get(TenantService.MAIN_TENANT, null, readerOutput.getUri()), r -> result.add((Map<String, Object>) r));
 
             assertThat(result.size(), is(1));
             assertThat(result.get(0).get("String"), is("string"));
@@ -203,7 +203,7 @@ class IonToParquetTest {
             ParquetToIon.Output readerOutput = reader.run(TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of()));
 
             List<Map<String, Object>> result = new ArrayList<>();
-            FileSerde.reader(new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, readerOutput.getUri()))), r -> result.add((Map<String, Object>) r));
+            FileSerde.read(storageInterface.get(TenantService.MAIN_TENANT, null, readerOutput.getUri()), r -> result.add((Map<String, Object>) r));
 
             assertThat(result.size(), is(3));
             assertThat(result.get(0).get("name"), is("Alice"));

--- a/src/test/java/io/kestra/plugin/serdes/parquet/ParquetToIonTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/parquet/ParquetToIonTest.java
@@ -93,7 +93,7 @@ class ParquetToIonTest {
             ParquetToIon.Output readerOutput = reader.run(TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of()));
 
             List<Map<String, Object>> result = new ArrayList<>();
-            FileSerde.reader(new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, readerOutput.getUri()))), r -> result.add((Map<String, Object>) r));
+            FileSerde.read(storageInterface.get(TenantService.MAIN_TENANT, null, readerOutput.getUri()), r -> result.add((Map<String, Object>) r));
 
             assertThat(result.size(), is(1));
             assertThat(result.get(0).get("String"), is("string"));

--- a/src/test/java/io/kestra/plugin/serdes/xml/XmlToIonWriterTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/xml/XmlToIonWriterTest.java
@@ -172,11 +172,7 @@ class XmlToIonWriterTest {
         // Read back ION records
         var records = new java.util.ArrayList<>();
         try (
-            var inputStream = new BufferedReader(
-                new InputStreamReader(
-                    runContextFactory.of().storage().getFile(readerOutput.getUri())
-                )
-            )
+            var inputStream = runContextFactory.of().storage().getFile(readerOutput.getUri())
         ) {
             FileSerde.readAll(inputStream).collectList().block().forEach(records::add);
         }
@@ -220,11 +216,7 @@ class XmlToIonWriterTest {
         // Read ION records
         var records = new java.util.ArrayList<>();
         try (
-            var inputStream = new BufferedReader(
-                new InputStreamReader(
-                    runContextFactory.of().storage().getFile(readerOutput.getUri())
-                )
-            )
+            var inputStream = runContextFactory.of().storage().getFile(readerOutput.getUri())
         ) {
             FileSerde.readAll(inputStream).collectList().block().forEach(records::add);
         }


### PR DESCRIPTION
## Summary
- Migrate all deprecated Reader/Writer-based FileSerde API calls to InputStream/OutputStream for binary ION compatibility (kestra/kestra#3155)
- Bump `kestraVersion` from 1.2.3 to 1.3.19
- Updated 15 source files and 5 test files across csv, xml, yaml, avro, parquet, excel, json, and protobuf modules

## Changes
- `FileSerde.readAll(Reader)` → `FileSerde.readAll(InputStream)`
- `FileSerde.writeAll(Writer, Flux)` → `FileSerde.writeAll(OutputStream, Flux)`
- `FileSerde.reader(Reader, Consumer)` → `FileSerde.read(InputStream, Consumer)`
- `BufferedReader(new InputStreamReader(...))` → `BufferedInputStream(...)` for FileSerde inputs
- `BufferedWriter(new FileWriter(...))` → `BufferedOutputStream(new FileOutputStream(...))` for FileSerde outputs
- Reader/Writer retained where needed for text-based parsing (CSV, JSON, YAML, XML output)

## Test plan
- [x] `./gradlew clean build -x test shadowJar` passes
- [x] `./gradlew compileTestJava` passes
- [ ] CI tests pass