### PR TITLE
fix(parquet): inferAllFields now scans all rows for schema inference

### DIFF
--- a/src/main/java/io/kestra/plugin/serdes/avro/AbstractAvroConverter.java
+++ b/src/main/java/io/kestra/plugin/serdes/avro/AbstractAvroConverter.java
@@ -161,7 +161,7 @@ public abstract class AbstractAvroConverter extends Task {
         if (Boolean.TRUE.equals(rInferAllFields)) {
             return Integer.MAX_VALUE;
         }
-        return runContext.render(this.numberOfRowsToScan).as(Integer.class).orElse(100);
+        return runContext.render(this.numberOfRowsToScan).as(Integer.class).orElseThrow();
     }
 
     protected <E extends Exception> Long convert(InputStream inputStream, org.apache.avro.Schema schema, Rethrow.ConsumerChecked<GenericData.Record, E> consumer, RunContext runContext)

--- a/src/main/java/io/kestra/plugin/serdes/avro/AbstractAvroConverter.java
+++ b/src/main/java/io/kestra/plugin/serdes/avro/AbstractAvroConverter.java
@@ -42,7 +42,9 @@ public abstract class AbstractAvroConverter extends Task {
     @Builder.Default
     @Schema(
         title = "Number of rows that will be scanned while inferring. The more rows scanned, the more precise the output schema will be",
-        description = "Only use when the 'schema' property is empty"
+        description = """
+            Only use when the 'schema' property is empty. \
+            Ignored for schema inference when `inferAllFields` is `true` — in that case, all rows are scanned."""
     )
     @PluginProperty(group = "advanced")
     private Property<Integer> numberOfRowsToScan = Property.ofValue(100);
@@ -128,8 +130,12 @@ public abstract class AbstractAvroConverter extends Task {
     @Builder.Default
     @Schema(
         title = "Try to infer all fields",
-        description = "If true, we try to infer all fields using `trueValues`, `falseValues`, and `nullValues`." +
-            "If false, we infer booleans and nulls only on fields declared in the schema as `null` or `bool`."
+        description = """
+            If `true`, schema inference scans **all rows** (ignoring `numberOfRowsToScan`) and attempts to infer \
+            all field types using `trueValues`, `falseValues`, and `nullValues`. \
+            This prevents fields that are null in the first scanned rows from being typed as NULL. \
+            If `false`, only the first `numberOfRowsToScan` rows are scanned, and booleans/nulls are inferred \
+            only on fields declared in the schema as `null` or `bool`."""
     )
     @PluginProperty(group = "advanced")
     protected Property<Boolean> inferAllFields = Property.ofValue(false);
@@ -149,6 +155,14 @@ public abstract class AbstractAvroConverter extends Task {
     )
     @PluginProperty(group = "advanced")
     protected final Property<OnBadLines> onBadLines = Property.ofValue(OnBadLines.ERROR);
+
+    protected int getEffectiveRowsToScan(RunContext runContext) throws IllegalVariableEvaluationException {
+        var rInferAllFields = runContext.render(this.inferAllFields).as(Boolean.class).orElse(false);
+        if (Boolean.TRUE.equals(rInferAllFields)) {
+            return Integer.MAX_VALUE;
+        }
+        return runContext.render(this.numberOfRowsToScan).as(Integer.class).orElse(100);
+    }
 
     protected <E extends Exception> Long convert(InputStream inputStream, org.apache.avro.Schema schema, Rethrow.ConsumerChecked<GenericData.Record, E> consumer, RunContext runContext)
         throws IOException, IllegalVariableEvaluationException {

--- a/src/main/java/io/kestra/plugin/serdes/avro/IonToAvro.java
+++ b/src/main/java/io/kestra/plugin/serdes/avro/IonToAvro.java
@@ -143,7 +143,7 @@ public class IonToAvro extends AbstractAvroConverter implements RunnableTask<Ion
             try (var inputStreamForInfer = runContext.storage().getFile(rFrom)) {
                 var schemaOutputStream = new ByteArrayOutputStream();
                 new InferAvroSchema(
-                    runContext.render(this.getNumberOfRowsToScan()).as(Integer.class).orElse(100)
+                    getEffectiveRowsToScan(runContext)
                 ).inferAvroSchemaFromIon(inputStreamForInfer, schemaOutputStream);
                 schema = schemaParser.parse(schemaOutputStream.toString(StandardCharsets.UTF_8));
             }

--- a/src/main/java/io/kestra/plugin/serdes/parquet/IonToParquet.java
+++ b/src/main/java/io/kestra/plugin/serdes/parquet/IonToParquet.java
@@ -168,7 +168,7 @@ public class IonToParquet extends AbstractAvroConverter implements RunnableTask<
             try (var inputStreamForInfer = runContext.storage().getFile(from)) {
                 var schemaOutputStream = new ByteArrayOutputStream();
                 new InferAvroSchema(
-                    runContext.render(this.getNumberOfRowsToScan()).as(Integer.class).orElse(100)
+                    getEffectiveRowsToScan(runContext)
                 ).inferAvroSchemaFromIon(inputStreamForInfer, schemaOutputStream);
                 schema = schemaParser.parse(schemaOutputStream.toString(StandardCharsets.UTF_8));
             }

--- a/src/test/java/io/kestra/plugin/serdes/avro/IonToAvroTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/avro/IonToAvroTest.java
@@ -5,9 +5,12 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.*;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericDatumReader;
@@ -159,6 +162,51 @@ class IonToAvroTest {
                 .build();
             writer.run(TestsUtils.mockRunContext(runContextFactory, writer, ImmutableMap.of()));
         }
+    }
+
+    @Test
+    void inferAllFieldsTrueScansAllRowsForDateField() throws Exception {
+        File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_infer_all_", ".ion");
+        try (OutputStream output = new FileOutputStream(tempFile)) {
+            // Rows 1–100: date field is null
+            IntStream.rangeClosed(1, 100).boxed()
+                .forEach(throwConsumer(i ->
+                {
+                    var row = new HashMap<String, Object>();
+                    row.put("id", i);
+                    row.put("event_date", null);
+                    FileSerde.write(output, row);
+                }));
+            // Rows 101–110: date field is non-null
+            IntStream.rangeClosed(101, 110).boxed()
+                .forEach(
+                    throwConsumer(
+                        i -> FileSerde.write(
+                            output,
+                            Map.of("id", i, "event_date", LocalDate.of(2024, 1, i - 100))
+                        )
+                    )
+                );
+        }
+
+        URI uri = storageInterface.put(
+            TenantService.MAIN_TENANT, null,
+            URI.create("/" + IdUtils.create() + ".ion"),
+            new FileInputStream(tempFile)
+        );
+
+        IonToAvro writer = IonToAvro.builder()
+            .id(IdUtils.create())
+            .type(IonToAvro.class.getName())
+            .from(Property.ofValue(uri.toString()))
+            .schema(null)
+            .inferAllFields(Property.ofValue(true))
+            .build();
+
+        // Must succeed: all rows are scanned so event_date is typed correctly (not NULL)
+        IonToAvro.Output output = writer.run(TestsUtils.mockRunContext(runContextFactory, writer, ImmutableMap.of()));
+
+        assertThat(avroSize(storageInterface.get(TenantService.MAIN_TENANT, null, output.getUri())), is(110));
     }
 
     @Test

--- a/src/test/java/io/kestra/plugin/serdes/parquet/IonToParquetTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/parquet/IonToParquetTest.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.*;
 import java.util.*;
+import java.util.stream.IntStream;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import jakarta.inject.Inject;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -212,5 +214,119 @@ class IonToParquetTest {
             assertThat(result.get(1).get("name"), is("Bob"));
             assertThat(result.get(2).get("name"), is("Charlie"));
         }
+    }
+
+    /**
+     * Verifies that inferAllFields=true scans all rows, so a date field that is null in the first 100
+     * rows is not permanently typed as NULL when non-null values appear from row 101 onward.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    void inferAllFieldsTrueScansAllRowsForDateField() throws Exception {
+        File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_infer_all_", ".ion");
+        try (OutputStream output = new FileOutputStream(tempFile)) {
+            // Rows 1–100: date field is null
+            IntStream.rangeClosed(1, 100).boxed()
+                .forEach(throwConsumer(i ->
+                {
+                    var row = new HashMap<String, Object>();
+                    row.put("id", i);
+                    row.put("event_date", null);
+                    FileSerde.write(output, row);
+                }));
+            // Row 101+: date field is non-null
+            IntStream.rangeClosed(101, 110).boxed()
+                .forEach(
+                    throwConsumer(
+                        i -> FileSerde.write(
+                            output,
+                            Map.of("id", i, "event_date", LocalDate.of(2024, 1, i - 100))
+                        )
+                    )
+                );
+        }
+
+        URI uri = storageInterface.put(
+            TenantService.MAIN_TENANT, null,
+            URI.create("/" + IdUtils.create() + ".ion"),
+            new FileInputStream(tempFile)
+        );
+
+        IonToParquet writer = IonToParquet.builder()
+            .id(IdUtils.create())
+            .type(IonToParquet.class.getName())
+            .from(Property.ofValue(uri.toString()))
+            .schema(null)
+            .inferAllFields(Property.ofValue(true))
+            .build();
+
+        // Must succeed: all rows are scanned so event_date is typed correctly (not NULL)
+        IonToParquet.Output writerOutput = writer.run(TestsUtils.mockRunContext(runContextFactory, writer, ImmutableMap.of()));
+
+        ParquetToIon reader = ParquetToIon.builder()
+            .id(IdUtils.create())
+            .type(ParquetToIon.class.getName())
+            .from(Property.ofValue(writerOutput.getUri().toString()))
+            .build();
+
+        ParquetToIon.Output readerOutput = reader.run(TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of()));
+
+        List<Map<String, Object>> result = new ArrayList<>();
+        FileSerde.read(storageInterface.get(TenantService.MAIN_TENANT, null, readerOutput.getUri()), r -> result.add((Map<String, Object>) r));
+
+        assertThat(result.size(), is(110));
+        // Rows 101–110 must have a non-null date
+        assertThat(result.stream().filter(r -> r.get("event_date") != null).count(), greaterThan(0L));
+    }
+
+    /**
+     * Verifies that inferAllFields=false (default) limits schema inference to numberOfRowsToScan rows,
+     * causing a type conflict when a date field is null in those rows but non-null later.
+     */
+    @Test
+    void inferAllFieldsFalseFailsWhenDateFieldNullInFirstRows() throws Exception {
+        File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_infer_limited_", ".ion");
+        try (OutputStream output = new FileOutputStream(tempFile)) {
+            // Rows 1–100: date field is null → inferred as NULL type
+            IntStream.rangeClosed(1, 100).boxed()
+                .forEach(throwConsumer(i ->
+                {
+                    var row = new HashMap<String, Object>();
+                    row.put("id", i);
+                    row.put("event_date", null);
+                    FileSerde.write(output, row);
+                }));
+            // Row 101+: date field is non-null → conflicts with NULL schema
+            IntStream.rangeClosed(101, 110).boxed()
+                .forEach(
+                    throwConsumer(
+                        i -> FileSerde.write(
+                            output,
+                            Map.of("id", i, "event_date", LocalDate.of(2024, 1, i - 100))
+                        )
+                    )
+                );
+        }
+
+        URI uri = storageInterface.put(
+            TenantService.MAIN_TENANT, null,
+            URI.create("/" + IdUtils.create() + ".ion"),
+            new FileInputStream(tempFile)
+        );
+
+        IonToParquet writer = IonToParquet.builder()
+            .id(IdUtils.create())
+            .type(IonToParquet.class.getName())
+            .from(Property.ofValue(uri.toString()))
+            .schema(null)
+            .inferAllFields(Property.ofValue(false))
+            .numberOfRowsToScan(Property.ofValue(100))
+            .build();
+
+        // Must throw: event_date was inferred as NULL but row 101 has a real date value
+        assertThrows(
+            Exception.class,
+            () -> writer.run(TestsUtils.mockRunContext(runContextFactory, writer, ImmutableMap.of()))
+        );
     }
 }

--- a/src/test/java/io/kestra/plugin/serdes/parquet/IonToParquetTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/parquet/IonToParquetTest.java
@@ -25,6 +25,7 @@ import jakarta.inject.Inject;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -216,10 +217,6 @@ class IonToParquetTest {
         }
     }
 
-    /**
-     * Verifies that inferAllFields=true scans all rows, so a date field that is null in the first 100
-     * rows is not permanently typed as NULL when non-null values appear from row 101 onward.
-     */
     @SuppressWarnings("unchecked")
     @Test
     void inferAllFieldsTrueScansAllRowsForDateField() throws Exception {
@@ -279,10 +276,6 @@ class IonToParquetTest {
         assertThat(result.stream().filter(r -> r.get("event_date") != null).count(), greaterThan(0L));
     }
 
-    /**
-     * Verifies that inferAllFields=false (default) limits schema inference to numberOfRowsToScan rows,
-     * causing a type conflict when a date field is null in those rows but non-null later.
-     */
     @Test
     void inferAllFieldsFalseFailsWhenDateFieldNullInFirstRows() throws Exception {
         File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_infer_limited_", ".ion");
@@ -324,9 +317,14 @@ class IonToParquetTest {
             .build();
 
         // Must throw: event_date was inferred as NULL but row 101 has a real date value
-        assertThrows(
-            Exception.class,
+        RuntimeException ex = assertThrows(
+            RuntimeException.class,
             () -> writer.run(TestsUtils.mockRunContext(runContextFactory, writer, ImmutableMap.of()))
         );
+        Throwable root = ex;
+        while (root.getCause() != null) {
+            root = root.getCause();
+        }
+        assertThat(root.getMessage(), containsString("Unknown type for null values"));
     }
 }


### PR DESCRIPTION
## Summary

- Added `getEffectiveRowsToScan(RunContext)` helper to `AbstractAvroConverter`: returns `Integer.MAX_VALUE` when `inferAllFields=true`, otherwise delegates to `numberOfRowsToScan`
- Updated `IonToAvro.run()` and `IonToParquet.run()` to call `getEffectiveRowsToScan(runContext)` instead of rendering `numberOfRowsToScan` directly when constructing `InferAvroSchema`
- Updated `@Schema` descriptions on `inferAllFields` and `numberOfRowsToScan` to document the new behaviour
- Added two tests in `IonToParquetTest`: one asserting success with `inferAllFields=true` on a dataset where a date field is null in rows 1–100 and non-null from row 101, and one asserting failure with the default `inferAllFields=false`

closes: https://github.com/kestra-io/plugin-serdes/issues/337

## Test plan

- [ ] `rtk test ./gradlew test` passes
- [ ] `inferAllFieldsTrueScansAllRowsForDateField` succeeds: writes and reads back 110 rows with a date field correctly typed
- [ ] `inferAllFieldsFalseFailsWhenDateFieldNullInFirstRows` throws an exception when a date field is null in the first 100 scanned rows but non-null thereafter

---
*[View as Artifact](https://claude.ai/code/artifact/cbc3caa2-8964-455f-b8f8-ff43b1683c12)*