### PR TITLE
chore(deps): bundle dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 plugins {
-    id 'io.kestra.gradle.repository-conventions' version '1.2.3'
-    id "io.kestra.gradle.plugin-doc-lint" version "1.2.4"
-    id 'io.kestra.gradle.spotless-conventions' version '1.2.4'
+    id 'io.kestra.gradle.repository-conventions' version '1.2.5'
+    id "io.kestra.gradle.plugin-doc-lint" version "1.2.5"
+    id 'io.kestra.gradle.spotless-conventions' version '1.2.5'
     id "com.vanniktech.maven.publish" version "0.37.0"
-    id "io.kestra.gradle.inject-bom-versions" version "1.2.4"
+    id "io.kestra.gradle.inject-bom-versions" version "1.2.5"
     id 'java-library'
     id "idea"
     id 'jacoco'
     id "com.adarshr.test-logger" version "4.0.0"
-    id "com.gradleup.shadow" version "9.4.2"
+    id "com.gradleup.shadow" version "9.4.3"
     id 'signing'
     id "com.github.ben-manes.versions" version "0.54.0"
     id 'net.researchgate.release' version '3.1.0'
@@ -65,7 +65,7 @@ dependencies {
     implementation "com.google.protobuf:protobuf-java:4.35.1"
     implementation "com.google.protobuf:protobuf-java-util:4.35.1"
 
-    implementation 'de.siegmar:fastcsv:4.3.0'
+    implementation 'de.siegmar:fastcsv:4.3.1'
     implementation ('org.apache.avro:avro:1.12.1') {
         exclude group: 'com.fasterxml.jackson.core'
     }
@@ -73,7 +73,7 @@ dependencies {
     implementation group: 'org.apache.poi', name: 'poi', version: '5.5.1'
     implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.5.1'
     implementation group: 'com.github.pjfanning', name: 'excel-streaming-reader', version: '5.2.0'
-    implementation("com.amazon.ion:ion-java:1.11.11")
+    implementation("com.amazon.ion:ion-java:1.12.0")
     implementation("org.apache.hadoop:hadoop-common:3.5.0") {
         exclude group: "org.slf4j"
         exclude group: "com.fasterxml.jackson.core"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
## Summary

Consolidates 5 dependabot PRs into one:

- kestra-gradle-plugins `1.2.3/1.2.4` → `1.2.5` (closes #340)
- `com.gradleup.shadow` `9.4.2` → `9.4.3` (closes #333)
- `de.siegmar:fastcsv` `4.3.0` → `4.3.1` (closes #341)
- `com.amazon.ion:ion-java` `1.11.11` → `1.12.0` (closes #335)
- gradle wrapper `9.6.0` → `9.6.1` (closes #330)

## Closes

Closes #330, #333, #335, #340, #341