### PR TITLE
fix(csv): strip UTF-8 BOM and drop trailing empty header column in CsvToIon

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     implementation "com.google.protobuf:protobuf-java-util:4.35.1"
 
     implementation 'de.siegmar:fastcsv:4.3.1'
+    implementation 'commons-io:commons-io' // for BOMInputStream
     implementation ('org.apache.avro:avro:1.12.1') {
         exclude group: 'com.fasterxml.jackson.core'
     }

--- a/src/main/java/io/kestra/plugin/serdes/OnEmptyHeader.java
+++ b/src/main/java/io/kestra/plugin/serdes/OnEmptyHeader.java
@@ -1,8 +1,5 @@
 package io.kestra.plugin.serdes;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-
-@Schema(title = "How to handle columns whose header name is empty (e.g. from a trailing field separator)")
 public enum OnEmptyHeader {
     /**
      * Drop trailing unnamed header columns and any values they hold. This is the default: it removes

--- a/src/main/java/io/kestra/plugin/serdes/OnEmptyHeader.java
+++ b/src/main/java/io/kestra/plugin/serdes/OnEmptyHeader.java
@@ -1,0 +1,18 @@
+package io.kestra.plugin.serdes;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "How to handle columns whose header name is empty (e.g. from a trailing field separator)")
+public enum OnEmptyHeader {
+    /**
+     * Drop trailing unnamed header columns and any values they hold. This is the default: it removes
+     * the empty column that a trailing field separator adds, which otherwise breaks downstream
+     * conversions (e.g. to Parquet). An empty name earlier in the header is kept as-is.
+     */
+    DROP,
+    /**
+     * Keep every column and give each unnamed one a generated name (col_0, col_1, ...), so no data
+     * is lost and downstream conversions still get valid column names.
+     */
+    RENAME
+}

--- a/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.serdes.csv;
 
 import java.io.*;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -24,12 +25,12 @@ import io.kestra.plugin.serdes.OnEmptyHeader;
 import de.siegmar.fastcsv.reader.CsvParseException;
 import de.siegmar.fastcsv.reader.CsvReader;
 import de.siegmar.fastcsv.reader.CsvRecord;
-import org.apache.commons.io.ByteOrderMark;
-import org.apache.commons.io.input.BOMInputStream;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.input.BOMInputStream;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -130,7 +131,9 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
     @Builder.Default
     @Schema(
         title = "How to handle columns whose header name is empty",
-        description = "`DROP` (default) removes trailing unnamed columns; `RENAME` keeps every column and names unnamed ones col_0, col_1, ... to avoid losing data."
+        description = """
+            `DROP` (default) removes trailing unnamed columns. \
+            `RENAME` keeps every column and names unnamed ones col_0, col_1, ... to avoid losing data."""
     )
     @PluginProperty(group = "advanced")
     private final Property<OnEmptyHeader> onEmptyHeader = Property.ofValue(OnEmptyHeader.DROP);
@@ -167,6 +170,7 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
     @Override
     public Output run(RunContext runContext) throws Exception {
         URI rFrom = new URI(runContext.render(this.from).as(String.class).orElseThrow());
+        String rCharset = runContext.render(charset).as(String.class).orElseThrow();
 
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
 
@@ -176,11 +180,8 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
         try (
             Reader reader = new BufferedReader(
                 new InputStreamReader(
-                    BOMInputStream.builder()
-                        .setInputStream(runContext.storage().getFile(rFrom))
-                        .setByteOrderMarks(ByteOrderMark.UTF_8)
-                        .get(),
-                    runContext.render(charset).as(String.class).orElseThrow()
+                    stripBomIfUtf8(runContext.storage().getFile(rFrom), rCharset),
+                    rCharset
                 ),
                 FileSerde.BUFFER_SIZE
             );
@@ -283,6 +284,20 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
     }
 
     /**
+     * Wraps the source stream to strip a leading UTF-8 byte-order mark, but only when the file is
+     * read as UTF-8. For any other charset those three bytes are real data, so they are left alone.
+     */
+    private static InputStream stripBomIfUtf8(InputStream in, String charsetName) throws IOException {
+        if (!StandardCharsets.UTF_8.equals(Charset.forName(charsetName))) {
+            return in;
+        }
+        return BOMInputStream.builder()
+            .setInputStream(in)
+            .setByteOrderMarks(ByteOrderMark.UTF_8)
+            .get();
+    }
+
+    /**
      * Populates {@code headers} from the header record and returns the number of columns to emit,
      * applying the {@code onEmptyHeader} policy to columns whose name is empty.
      */
@@ -319,6 +334,17 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
             runContext.logger().warn(
                 "Dropped {} trailing unnamed header column(s); their values are not emitted. Set onEmptyHeader=RENAME to keep them.",
                 names.size() - kept
+            );
+        }
+
+        // Any empty or duplicate name left among the kept columns maps to the same output key, so
+        // only the last such column's value survives. Warn rather than lose data silently (this
+        // covers an all-empty header, which cannot be trimmed without collapsing every row).
+        long distinctKept = IntStream.range(0, kept).mapToObj(names::get).distinct().count();
+        if (distinctKept < kept) {
+            runContext.logger().warn(
+                "Header has {} duplicate or empty column name(s) among the kept columns. Colliding columns share one output key and only the last value is kept. Set onEmptyHeader=RENAME to keep every column.",
+                kept - distinctKept
             );
         }
         return kept;

--- a/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
@@ -41,7 +41,10 @@ import reactor.core.publisher.Mono;
     description = """
         Supports configurable field separator, text delimiter, charset, and \
         header detection. The value `\\N` is treated as null in any field. \
-        Use `onBadLines` to control error handling for malformed rows."""
+        Use `onBadLines` to control error handling for malformed rows. \
+        A leading UTF-8 byte-order mark is stripped automatically, and a trailing \
+        unnamed header column (e.g. from a trailing field separator) is dropped \
+        with a warning logged."""
 )
 @Plugin(
     examples = {
@@ -206,6 +209,12 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
                         int trailing = csvRecord.getFieldCount();
                         while (trailing > 0 && headers.get(trailing - 1).isEmpty()) {
                             trailing--;
+                        }
+                        if (trailing == 0) {
+                            // The entire header is empty (e.g. ";;;"): trimming would leave zero
+                            // columns and every row would collapse to an empty record. There's no
+                            // artifact to safely drop here, so keep every column as-is instead.
+                            trailing = csvRecord.getFieldCount();
                         }
                         effectiveHeaderCount.set(trailing);
                         int droppedCount = csvRecord.getFieldCount() - trailing;

--- a/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
@@ -286,38 +287,38 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
      * applying the {@code onEmptyHeader} policy to columns whose name is empty.
      */
     private int resolveHeaders(CsvRecord header, Map<Integer, String> headers, OnEmptyHeader onEmptyHeader, RunContext runContext) {
-        int count = header.getFieldCount();
-        for (int i = 0; i < count; i++) {
-            headers.put(i, header.getField(i));
-        }
+        List<String> names = header.getFields();
+        IntStream.range(0, names.size()).forEach(index -> headers.put(index, names.get(index)));
 
         if (onEmptyHeader == OnEmptyHeader.RENAME) {
-            Set<String> usedNames = new HashSet<>(headers.values());
-            for (int i = 0; i < count; i++) {
-                if (headers.get(i).isEmpty()) {
-                    String name = "col_" + i;
-                    for (int suffix = 2; usedNames.contains(name); suffix++) {
-                        name = "col_" + i + "_" + suffix;
-                    }
-                    headers.put(i, name);
-                    usedNames.add(name);
+            // Name every unnamed column uniquely, so no data is lost and Parquet gets valid names.
+            Set<String> taken = new HashSet<>(names);
+            headers.replaceAll((index, name) -> {
+                if (!name.isEmpty()) {
+                    return name;
                 }
-            }
-            return count;
+                String unique = IntStream.iterate(1, attempt -> attempt + 1)
+                    .mapToObj(attempt -> attempt == 1 ? "col_" + index : "col_" + index + "_" + attempt)
+                    .filter(candidate -> !taken.contains(candidate))
+                    .findFirst()
+                    .orElseThrow();
+                taken.add(unique);
+                return unique;
+            });
+            return names.size();
         }
 
-        // DROP: trim the trailing run of unnamed columns, but never down to zero columns.
-        int kept = count;
-        while (kept > 0 && headers.get(kept - 1).isEmpty()) {
-            kept--;
-        }
-        if (kept == 0) {
-            return count;
-        }
-        if (kept < count) {
+        // DROP: drop the trailing run of unnamed columns (e.g. a trailing separator), but keep at
+        // least one column so rows never collapse to an empty record.
+        int kept = IntStream.range(0, names.size())
+            .filter(index -> !names.get(index).isEmpty())
+            .max()
+            .orElse(names.size() - 1) + 1;
+
+        if (kept < names.size()) {
             runContext.logger().warn(
                 "Dropped {} trailing unnamed header column(s); their values are not emitted. Set onEmptyHeader=RENAME to keep them.",
-                count - kept
+                names.size() - kept
             );
         }
         return kept;

--- a/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
@@ -22,6 +22,8 @@ import io.kestra.plugin.serdes.OnBadLines;
 import de.siegmar.fastcsv.reader.CsvParseException;
 import de.siegmar.fastcsv.reader.CsvReader;
 import de.siegmar.fastcsv.reader.CsvRecord;
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.input.BOMInputStream;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -160,7 +162,10 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
         try (
             Reader reader = new BufferedReader(
                 new InputStreamReader(
-                    this.stripUtf8Bom(runContext.storage().getFile(rFrom)),
+                    BOMInputStream.builder()
+                        .setInputStream(runContext.storage().getFile(rFrom))
+                        .setByteOrderMarks(ByteOrderMark.UTF_8)
+                        .get(),
                     runContext.render(charset).as(String.class).orElseThrow()
                 ),
                 FileSerde.BUFFER_SIZE
@@ -171,7 +176,7 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
             var rHeaderValue = runContext.render(header).as(Boolean.class).orElseThrow();
             var rSkipRowsValue = runContext.render(this.skipRows).as(Integer.class).orElseThrow();
             Map<Integer, String> headers = new TreeMap<>();
-            Set<Integer> trailingEmptyHeaderColumns = new HashSet<>();
+            AtomicInteger effectiveHeaderCount = new AtomicInteger();
             OnBadLines rOnBadLinesValue = runContext.render(this.onBadLines).as(OnBadLines.class).orElse(OnBadLines.ERROR);
 
             Flux<Object> flowable = Flux
@@ -193,20 +198,21 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
                         for (int i = 0; i < csvRecord.getFieldCount(); i++) {
                             headers.put(i, csvRecord.getField(i));
                         }
-                        // Identify trailing empty-named columns (e.g. from a trailing field separator on
-                        // the header line): left as-is, an unnamed field surfaces as an unusable "" field
-                        // in the Ion output and breaks downstream conversions (e.g. to Parquet). Only
-                        // *trailing* empty names are treated as this artifact - an empty name in the
-                        // middle of the header is a structural property of the data itself and is kept.
+                        // Trailing empty-named columns are always a contiguous run at the end of the
+                        // header line (e.g. from a trailing field separator): left as-is, an unnamed
+                        // field surfaces as an unusable "" field in the Ion output and breaks downstream
+                        // conversions (e.g. to Parquet). An empty name earlier in the header is a
+                        // structural property of the data itself and is kept as-is.
                         int trailing = csvRecord.getFieldCount();
-                        while (trailing > 0 && headers.get(trailing - 1) != null && headers.get(trailing - 1).isEmpty()) {
-                            trailingEmptyHeaderColumns.add(trailing - 1);
+                        while (trailing > 0 && headers.get(trailing - 1).isEmpty()) {
                             trailing--;
                         }
-                        if (!trailingEmptyHeaderColumns.isEmpty()) {
+                        effectiveHeaderCount.set(trailing);
+                        int droppedCount = csvRecord.getFieldCount() - trailing;
+                        if (droppedCount > 0) {
                             runContext.logger().warn(
-                                "Dropping {} trailing unnamed column(s) from the CSV header (likely caused by a trailing field separator): column index(es) {}",
-                                trailingEmptyHeaderColumns.size(), trailingEmptyHeaderColumns
+                                "Dropping {} trailing unnamed column(s) from the CSV header (likely caused by a trailing field separator)",
+                                droppedCount
                             );
                         }
                         return false;
@@ -238,16 +244,12 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
                             }
                             return Mono.empty();
                         }
-                        for (Map.Entry<Integer, String> header : headers.entrySet()) {
-                            int i = header.getKey();
-                            if (trailingEmptyHeaderColumns.contains(i)) {
-                                continue;
-                            }
+                        for (int i = 0; i < effectiveHeaderCount.get(); i++) {
                             String fieldValue = i < r.getFieldCount() ? r.getField(i) : null;
                             if ("\\N".equals(fieldValue)) {
                                 fieldValue = null;
                             }
-                            fields.put(header.getValue(), fieldValue);
+                            fields.put(headers.get(i), fieldValue);
                         }
                         return Mono.just(fields);
                     } else {
@@ -317,32 +319,5 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
 
         var handler = handlerBuilder.build();
         return builder.build(handler, reader);
-    }
-
-    /**
-     * Strips a leading UTF-8 byte-order mark (EF BB BF), if present, so it doesn't leak into the
-     * first field's name/value (e.g. as an invisible character prepended to the first header).
-     * <p>
-     * This is done manually rather than via {@code CsvReaderBuilder#detectBomHeader(true)} because
-     * that option only takes effect when building from an {@code InputStream}, and doing so shrinks
-     * the effective capacity of a user-configured {@code maxBufferSize} enough to make small buffer
-     * sizes (e.g. the ones used to bound pathological fields) fail unexpectedly. Peeking 3 raw bytes
-     * here is fully decoupled from fastcsv's internal buffering.
-     */
-    private InputStream stripUtf8Bom(InputStream inputStream) throws IOException {
-        PushbackInputStream pushbackInputStream = new PushbackInputStream(inputStream, 3);
-        byte[] possibleBom = new byte[3];
-        int read = pushbackInputStream.read(possibleBom, 0, 3);
-
-        boolean isUtf8Bom = read == 3
-            && (possibleBom[0] & 0xFF) == 0xEF
-            && (possibleBom[1] & 0xFF) == 0xBB
-            && (possibleBom[2] & 0xFF) == 0xBF;
-
-        if (!isUtf8Bom && read > 0) {
-            pushbackInputStream.unread(possibleBom, 0, read);
-        }
-
-        return pushbackInputStream;
     }
 }

--- a/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
@@ -215,9 +215,18 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
                         if (rOnEmptyHeaderValue == OnEmptyHeader.RENAME) {
                             // Keep every column; give each unnamed one a generated name so no data is
                             // lost and downstream conversions (e.g. to Parquet) get valid column names.
+                            // The generated name is disambiguated against existing (and already
+                            // generated) names so it can never collide with a real column literally
+                            // named "col_<n>" and silently overwrite it.
+                            Set<String> usedNames = new HashSet<>(headers.values());
                             for (int i = 0; i < csvRecord.getFieldCount(); i++) {
                                 if (headers.get(i).isEmpty()) {
-                                    headers.put(i, "col_" + i);
+                                    String name = "col_" + i;
+                                    for (int suffix = 2; usedNames.contains(name); suffix++) {
+                                        name = "col_" + i + "_" + suffix;
+                                    }
+                                    headers.put(i, name);
+                                    usedNames.add(name);
                                 }
                             }
                             effectiveHeaderCount.set(csvRecord.getFieldCount());

--- a/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
@@ -18,6 +18,7 @@ import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.FileSerde;
 import io.kestra.plugin.serdes.OnBadLines;
+import io.kestra.plugin.serdes.OnEmptyHeader;
 
 import de.siegmar.fastcsv.reader.CsvParseException;
 import de.siegmar.fastcsv.reader.CsvReader;
@@ -42,9 +43,10 @@ import reactor.core.publisher.Mono;
         Supports configurable field separator, text delimiter, charset, and \
         header detection. The value `\\N` is treated as null in any field. \
         Use `onBadLines` to control error handling for malformed rows. \
-        A leading UTF-8 byte-order mark is stripped automatically, and a trailing \
-        unnamed header column (e.g. from a trailing field separator) is dropped \
-        with a warning logged."""
+        A leading UTF-8 byte-order mark is stripped automatically. Trailing unnamed \
+        header columns (e.g. from a trailing field separator) are dropped by default; \
+        set `onEmptyHeader` to `RENAME` to keep them with generated names (col_0, col_1, ...) \
+        instead."""
 )
 @Plugin(
     examples = {
@@ -126,6 +128,14 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
 
     @Builder.Default
     @Schema(
+        title = "How to handle columns whose header name is empty",
+        description = "`DROP` (default) removes trailing unnamed columns; `RENAME` keeps every column and names unnamed ones col_0, col_1, ... to avoid losing data."
+    )
+    @PluginProperty(group = "advanced")
+    private final Property<OnEmptyHeader> onEmptyHeader = Property.ofValue(OnEmptyHeader.DROP);
+
+    @Builder.Default
+    @Schema(
         title = "Number of lines to skip at the start of the file"
     )
     @PluginProperty(group = "advanced")
@@ -181,6 +191,7 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
             Map<Integer, String> headers = new TreeMap<>();
             AtomicInteger effectiveHeaderCount = new AtomicInteger();
             OnBadLines rOnBadLinesValue = runContext.render(this.onBadLines).as(OnBadLines.class).orElse(OnBadLines.ERROR);
+            OnEmptyHeader rOnEmptyHeaderValue = runContext.render(this.onEmptyHeader).as(OnEmptyHeader.class).orElse(OnEmptyHeader.DROP);
 
             Flux<Object> flowable = Flux
                 .fromIterable(csvReader)
@@ -201,28 +212,39 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
                         for (int i = 0; i < csvRecord.getFieldCount(); i++) {
                             headers.put(i, csvRecord.getField(i));
                         }
-                        // Trailing empty-named columns are always a contiguous run at the end of the
-                        // header line (e.g. from a trailing field separator): left as-is, an unnamed
-                        // field surfaces as an unusable "" field in the Ion output and breaks downstream
-                        // conversions (e.g. to Parquet). An empty name earlier in the header is a
-                        // structural property of the data itself and is kept as-is.
-                        int trailing = csvRecord.getFieldCount();
-                        while (trailing > 0 && headers.get(trailing - 1).isEmpty()) {
-                            trailing--;
-                        }
-                        if (trailing == 0) {
-                            // The entire header is empty (e.g. ";;;"): trimming would leave zero
-                            // columns and every row would collapse to an empty record. There's no
-                            // artifact to safely drop here, so keep every column as-is instead.
-                            trailing = csvRecord.getFieldCount();
-                        }
-                        effectiveHeaderCount.set(trailing);
-                        int droppedCount = csvRecord.getFieldCount() - trailing;
-                        if (droppedCount > 0) {
-                            runContext.logger().warn(
-                                "Dropping {} trailing unnamed column(s) from the CSV header (likely caused by a trailing field separator)",
-                                droppedCount
-                            );
+                        if (rOnEmptyHeaderValue == OnEmptyHeader.RENAME) {
+                            // Keep every column; give each unnamed one a generated name so no data is
+                            // lost and downstream conversions (e.g. to Parquet) get valid column names.
+                            for (int i = 0; i < csvRecord.getFieldCount(); i++) {
+                                if (headers.get(i).isEmpty()) {
+                                    headers.put(i, "col_" + i);
+                                }
+                            }
+                            effectiveHeaderCount.set(csvRecord.getFieldCount());
+                        } else {
+                            // DROP (default): trailing empty-named columns are always a contiguous run at
+                            // the end of the header line (e.g. from a trailing field separator). Left
+                            // as-is, an unnamed field surfaces as an unusable "" field in the Ion output
+                            // and breaks downstream conversions. An empty name earlier in the header is a
+                            // structural property of the data itself and is kept as-is.
+                            int trailing = csvRecord.getFieldCount();
+                            while (trailing > 0 && headers.get(trailing - 1).isEmpty()) {
+                                trailing--;
+                            }
+                            if (trailing == 0) {
+                                // The entire header is empty (e.g. ";;;"): trimming would leave zero
+                                // columns and every row would collapse to an empty record. There's no
+                                // artifact to safely drop here, so keep every column as-is instead.
+                                trailing = csvRecord.getFieldCount();
+                            }
+                            effectiveHeaderCount.set(trailing);
+                            int droppedCount = csvRecord.getFieldCount() - trailing;
+                            if (droppedCount > 0) {
+                                runContext.logger().warn(
+                                    "Dropped {} trailing unnamed header column(s); any values in those columns are not emitted. Set onEmptyHeader=RENAME to keep them.",
+                                    droppedCount
+                                );
+                            }
                         }
                         return false;
                     }
@@ -237,12 +259,6 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
                 {
                     if (rHeaderValue) {
                         Map<String, Object> fields = new LinkedHashMap<>();
-                        if (r.getStartingLineNumber() == 1) {
-                            for (int i = 0; i < r.getFieldCount(); i++) {
-                                headers.put(i, r.getField(i));
-                            }
-                            return Mono.empty();
-                        }
                         if (r.getFieldCount() != headers.size()) {
                             String message = "Bad line encountered (field count mismatch): Expected "
                                 + headers.size() + ", got " + r.getFieldCount() + " fields.";

--- a/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
@@ -171,7 +171,7 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
             var rHeaderValue = runContext.render(header).as(Boolean.class).orElseThrow();
             var rSkipRowsValue = runContext.render(this.skipRows).as(Integer.class).orElseThrow();
             Map<Integer, String> headers = new TreeMap<>();
-            AtomicInteger rawHeaderFieldCount = new AtomicInteger();
+            Set<Integer> trailingEmptyHeaderColumns = new HashSet<>();
             OnBadLines rOnBadLinesValue = runContext.render(this.onBadLines).as(OnBadLines.class).orElse(OnBadLines.ERROR);
 
             Flux<Object> flowable = Flux
@@ -193,14 +193,21 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
                         for (int i = 0; i < csvRecord.getFieldCount(); i++) {
                             headers.put(i, csvRecord.getField(i));
                         }
-                        rawHeaderFieldCount.set(csvRecord.getFieldCount());
-                        // Drop trailing empty-named columns (e.g. from a trailing field separator in the
-                        // header line): an unnamed field otherwise surfaces as an unusable "" field in the
-                        // Ion output and breaks downstream conversions (e.g. to Parquet).
+                        // Identify trailing empty-named columns (e.g. from a trailing field separator on
+                        // the header line): left as-is, an unnamed field surfaces as an unusable "" field
+                        // in the Ion output and breaks downstream conversions (e.g. to Parquet). Only
+                        // *trailing* empty names are treated as this artifact - an empty name in the
+                        // middle of the header is a structural property of the data itself and is kept.
                         int trailing = csvRecord.getFieldCount();
                         while (trailing > 0 && headers.get(trailing - 1) != null && headers.get(trailing - 1).isEmpty()) {
-                            headers.remove(trailing - 1);
+                            trailingEmptyHeaderColumns.add(trailing - 1);
                             trailing--;
+                        }
+                        if (!trailingEmptyHeaderColumns.isEmpty()) {
+                            runContext.logger().warn(
+                                "Dropping {} trailing unnamed column(s) from the CSV header (likely caused by a trailing field separator): column index(es) {}",
+                                trailingEmptyHeaderColumns.size(), trailingEmptyHeaderColumns
+                            );
                         }
                         return false;
                     }
@@ -221,9 +228,9 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
                             }
                             return Mono.empty();
                         }
-                        if (r.getFieldCount() != rawHeaderFieldCount.get()) {
+                        if (r.getFieldCount() != headers.size()) {
                             String message = "Bad line encountered (field count mismatch): Expected "
-                                + rawHeaderFieldCount.get() + ", got " + r.getFieldCount() + " fields.";
+                                + headers.size() + ", got " + r.getFieldCount() + " fields.";
                             if (rOnBadLinesValue == OnBadLines.ERROR) {
                                 return Mono.error(new RuntimeException(message));
                             } else if (rOnBadLinesValue == OnBadLines.WARN) {
@@ -233,6 +240,9 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
                         }
                         for (Map.Entry<Integer, String> header : headers.entrySet()) {
                             int i = header.getKey();
+                            if (trailingEmptyHeaderColumns.contains(i)) {
+                                continue;
+                            }
                             String fieldValue = i < r.getFieldCount() ? r.getField(i) : null;
                             if ("\\N".equals(fieldValue)) {
                                 fieldValue = null;
@@ -312,6 +322,12 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
     /**
      * Strips a leading UTF-8 byte-order mark (EF BB BF), if present, so it doesn't leak into the
      * first field's name/value (e.g. as an invisible character prepended to the first header).
+     * <p>
+     * This is done manually rather than via {@code CsvReaderBuilder#detectBomHeader(true)} because
+     * that option only takes effect when building from an {@code InputStream}, and doing so shrinks
+     * the effective capacity of a user-configured {@code maxBufferSize} enough to make small buffer
+     * sizes (e.g. the ones used to bound pathological fields) fail unexpectedly. Peeking 3 raw bytes
+     * here is fully decoupled from fastcsv's internal buffering.
      */
     private InputStream stripUtf8Bom(InputStream inputStream) throws IOException {
         PushbackInputStream pushbackInputStream = new PushbackInputStream(inputStream, 3);

--- a/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
@@ -160,7 +160,7 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
         try (
             Reader reader = new BufferedReader(
                 new InputStreamReader(
-                    runContext.storage().getFile(rFrom),
+                    this.stripUtf8Bom(runContext.storage().getFile(rFrom)),
                     runContext.render(charset).as(String.class).orElseThrow()
                 ),
                 FileSerde.BUFFER_SIZE
@@ -171,6 +171,7 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
             var rHeaderValue = runContext.render(header).as(Boolean.class).orElseThrow();
             var rSkipRowsValue = runContext.render(this.skipRows).as(Integer.class).orElseThrow();
             Map<Integer, String> headers = new TreeMap<>();
+            AtomicInteger rawHeaderFieldCount = new AtomicInteger();
             OnBadLines rOnBadLinesValue = runContext.render(this.onBadLines).as(OnBadLines.class).orElse(OnBadLines.ERROR);
 
             Flux<Object> flowable = Flux
@@ -192,6 +193,15 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
                         for (int i = 0; i < csvRecord.getFieldCount(); i++) {
                             headers.put(i, csvRecord.getField(i));
                         }
+                        rawHeaderFieldCount.set(csvRecord.getFieldCount());
+                        // Drop trailing empty-named columns (e.g. from a trailing field separator in the
+                        // header line): an unnamed field otherwise surfaces as an unusable "" field in the
+                        // Ion output and breaks downstream conversions (e.g. to Parquet).
+                        int trailing = csvRecord.getFieldCount();
+                        while (trailing > 0 && headers.get(trailing - 1) != null && headers.get(trailing - 1).isEmpty()) {
+                            headers.remove(trailing - 1);
+                            trailing--;
+                        }
                         return false;
                     }
                     if (rSkipRowsValue > 0 && skipped.get() < rSkipRowsValue) {
@@ -211,9 +221,9 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
                             }
                             return Mono.empty();
                         }
-                        if (r.getFieldCount() != headers.size()) {
+                        if (r.getFieldCount() != rawHeaderFieldCount.get()) {
                             String message = "Bad line encountered (field count mismatch): Expected "
-                                + headers.size() + ", got " + r.getFieldCount() + " fields.";
+                                + rawHeaderFieldCount.get() + ", got " + r.getFieldCount() + " fields.";
                             if (rOnBadLinesValue == OnBadLines.ERROR) {
                                 return Mono.error(new RuntimeException(message));
                             } else if (rOnBadLinesValue == OnBadLines.WARN) {
@@ -297,5 +307,26 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
 
         var handler = handlerBuilder.build();
         return builder.build(handler, reader);
+    }
+
+    /**
+     * Strips a leading UTF-8 byte-order mark (EF BB BF), if present, so it doesn't leak into the
+     * first field's name/value (e.g. as an invisible character prepended to the first header).
+     */
+    private InputStream stripUtf8Bom(InputStream inputStream) throws IOException {
+        PushbackInputStream pushbackInputStream = new PushbackInputStream(inputStream, 3);
+        byte[] possibleBom = new byte[3];
+        int read = pushbackInputStream.read(possibleBom, 0, 3);
+
+        boolean isUtf8Bom = read == 3
+            && (possibleBom[0] & 0xFF) == 0xEF
+            && (possibleBom[1] & 0xFF) == 0xBB
+            && (possibleBom[2] & 0xFF) == 0xBF;
+
+        if (!isUtf8Bom && read > 0) {
+            pushbackInputStream.unread(possibleBom, 0, read);
+        }
+
+        return pushbackInputStream;
     }
 }

--- a/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
+++ b/src/main/java/io/kestra/plugin/serdes/csv/CsvToIon.java
@@ -209,52 +209,7 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
                 .filter(csvRecord ->
                 {
                     if (rHeaderValue && csvRecord.getStartingLineNumber() == 1) {
-                        for (int i = 0; i < csvRecord.getFieldCount(); i++) {
-                            headers.put(i, csvRecord.getField(i));
-                        }
-                        if (rOnEmptyHeaderValue == OnEmptyHeader.RENAME) {
-                            // Keep every column; give each unnamed one a generated name so no data is
-                            // lost and downstream conversions (e.g. to Parquet) get valid column names.
-                            // The generated name is disambiguated against existing (and already
-                            // generated) names so it can never collide with a real column literally
-                            // named "col_<n>" and silently overwrite it.
-                            Set<String> usedNames = new HashSet<>(headers.values());
-                            for (int i = 0; i < csvRecord.getFieldCount(); i++) {
-                                if (headers.get(i).isEmpty()) {
-                                    String name = "col_" + i;
-                                    for (int suffix = 2; usedNames.contains(name); suffix++) {
-                                        name = "col_" + i + "_" + suffix;
-                                    }
-                                    headers.put(i, name);
-                                    usedNames.add(name);
-                                }
-                            }
-                            effectiveHeaderCount.set(csvRecord.getFieldCount());
-                        } else {
-                            // DROP (default): trailing empty-named columns are always a contiguous run at
-                            // the end of the header line (e.g. from a trailing field separator). Left
-                            // as-is, an unnamed field surfaces as an unusable "" field in the Ion output
-                            // and breaks downstream conversions. An empty name earlier in the header is a
-                            // structural property of the data itself and is kept as-is.
-                            int trailing = csvRecord.getFieldCount();
-                            while (trailing > 0 && headers.get(trailing - 1).isEmpty()) {
-                                trailing--;
-                            }
-                            if (trailing == 0) {
-                                // The entire header is empty (e.g. ";;;"): trimming would leave zero
-                                // columns and every row would collapse to an empty record. There's no
-                                // artifact to safely drop here, so keep every column as-is instead.
-                                trailing = csvRecord.getFieldCount();
-                            }
-                            effectiveHeaderCount.set(trailing);
-                            int droppedCount = csvRecord.getFieldCount() - trailing;
-                            if (droppedCount > 0) {
-                                runContext.logger().warn(
-                                    "Dropped {} trailing unnamed header column(s); any values in those columns are not emitted. Set onEmptyHeader=RENAME to keep them.",
-                                    droppedCount
-                                );
-                            }
-                        }
+                        effectiveHeaderCount.set(this.resolveHeaders(csvRecord, headers, rOnEmptyHeaderValue, runContext));
                         return false;
                     }
                     if (rSkipRowsValue > 0 && skipped.get() < rSkipRowsValue) {
@@ -324,6 +279,48 @@ public class CsvToIon extends Task implements RunnableTask<CsvToIon.Output> {
 
         @Schema(title = "The number of records converted")
         private long size;
+    }
+
+    /**
+     * Populates {@code headers} from the header record and returns the number of columns to emit,
+     * applying the {@code onEmptyHeader} policy to columns whose name is empty.
+     */
+    private int resolveHeaders(CsvRecord header, Map<Integer, String> headers, OnEmptyHeader onEmptyHeader, RunContext runContext) {
+        int count = header.getFieldCount();
+        for (int i = 0; i < count; i++) {
+            headers.put(i, header.getField(i));
+        }
+
+        if (onEmptyHeader == OnEmptyHeader.RENAME) {
+            Set<String> usedNames = new HashSet<>(headers.values());
+            for (int i = 0; i < count; i++) {
+                if (headers.get(i).isEmpty()) {
+                    String name = "col_" + i;
+                    for (int suffix = 2; usedNames.contains(name); suffix++) {
+                        name = "col_" + i + "_" + suffix;
+                    }
+                    headers.put(i, name);
+                    usedNames.add(name);
+                }
+            }
+            return count;
+        }
+
+        // DROP: trim the trailing run of unnamed columns, but never down to zero columns.
+        int kept = count;
+        while (kept > 0 && headers.get(kept - 1).isEmpty()) {
+            kept--;
+        }
+        if (kept == 0) {
+            return count;
+        }
+        if (kept < count) {
+            runContext.logger().warn(
+                "Dropped {} trailing unnamed header column(s); their values are not emitted. Set onEmptyHeader=RENAME to keep them.",
+                count - kept
+            );
+        }
+        return kept;
     }
 
     private CsvReader<CsvRecord> csvReader(Reader reader, RunContext runContext) throws IllegalVariableEvaluationException {

--- a/src/main/resources/doc/io.kestra.plugin.serdes.md
+++ b/src/main/resources/doc/io.kestra.plugin.serdes.md
@@ -8,7 +8,7 @@ All tasks require `from` (a `kestra://` URI pointing to the source file) and ret
 
 ### CSV
 
-`csv.CsvToIon` converts a CSV file to ION — set `from`. Control parsing with `header` (default `true`), `fieldSeparator` (default `,`), `textDelimiter` (default `"`), `skipEmptyRows` (default `false`), `skipRows` (default 0), `charset` (default `UTF-8`), and `onBadLines` (default `ERROR`; also `WARN` or `SKIP`).
+`csv.CsvToIon` converts a CSV file to ION — set `from`. Control parsing with `header` (default `true`), `fieldSeparator` (default `,`), `textDelimiter` (default `"`), `skipEmptyRows` (default `false`), `skipRows` (default 0), `charset` (default `UTF-8`), and `onBadLines` (default `ERROR`; also `WARN` or `SKIP`). A leading UTF-8 byte-order mark is stripped automatically. Use `onEmptyHeader` (default `DROP`) to drop trailing unnamed header columns, or `RENAME` to keep them with generated names (`col_0`, `col_1`, ...).
 
 `csv.IonToCsv` converts an ION file to CSV — set `from`. Control output with `header` (default `true`), `fieldSeparator` (default `,`), `textDelimiter` (default `"`), `lineDelimiter` (default `\n`), `quoteMode` (`ALWAYS`, `REQUIRED`, or `NON_NUMERIC`), and `charset` (default `UTF-8`). Inherits date/time formatting from the base writer.
 

--- a/src/test/java/io/kestra/plugin/serdes/csv/CsvToIonWriterTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/csv/CsvToIonWriterTest.java
@@ -302,6 +302,102 @@ class CsvToIonWriterTest {
     }
 
     @Test
+    void multipleTrailingEmptyHeaderColumnsAreDropped() throws Exception {
+        // Two trailing separators in a row should drop both empty-named trailing columns, not just one.
+        String csvBody = "code_insee;nom_commune;;\n1001;L'Abergement-Clémenciat;;\n";
+
+        URI src = storageInterface.put(
+            TenantService.MAIN_TENANT, null, URI.create("/multiTrailingEmptyHeader.csv"),
+            new ByteArrayInputStream(csvBody.getBytes(StandardCharsets.UTF_8))
+        );
+
+        CsvToIon reader = CsvToIon.builder()
+            .id("multipleTrailingEmptyHeaderColumnsAreDropped")
+            .type(CsvToIon.class.getName())
+            .from(Property.ofValue(src.toString()))
+            .fieldSeparator(Property.ofValue(';'))
+            .header(Property.ofValue(true))
+            .build();
+
+        CsvToIon.Output out = reader.run(TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of()));
+
+        List<Object> rows;
+        try (var in = storageInterface.get(TenantService.MAIN_TENANT, null, out.getUri())) {
+            rows = FileSerde.readAll(in).collectList().block();
+        }
+
+        assertThat(rows, hasSize(1));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> row = (Map<String, Object>) rows.get(0);
+        assertThat(row.keySet(), not(hasItem("")));
+        assertThat(row.keySet(), containsInAnyOrder("code_insee", "nom_commune"));
+    }
+
+    @Test
+    void allEmptyHeaderIsNotTrimmedToZeroColumns() throws Exception {
+        // Edge case: if the whole header is empty (e.g. ";;;"), trimming every column would leave
+        // zero columns and every row would collapse to an empty record. There's no "real" header
+        // left to anchor the trim against, so nothing is dropped in this case.
+        String csvBody = ";;;\n1;2;3;4\n";
+
+        URI src = storageInterface.put(
+            TenantService.MAIN_TENANT, null, URI.create("/allEmptyHeader.csv"),
+            new ByteArrayInputStream(csvBody.getBytes(StandardCharsets.UTF_8))
+        );
+
+        CsvToIon reader = CsvToIon.builder()
+            .id("allEmptyHeaderIsNotTrimmedToZeroColumns")
+            .type(CsvToIon.class.getName())
+            .from(Property.ofValue(src.toString()))
+            .fieldSeparator(Property.ofValue(';'))
+            .header(Property.ofValue(true))
+            .build();
+
+        CsvToIon.Output out = reader.run(TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of()));
+
+        List<Object> rows;
+        try (var in = storageInterface.get(TenantService.MAIN_TENANT, null, out.getUri())) {
+            rows = FileSerde.readAll(in).collectList().block();
+        }
+
+        assertThat(rows, hasSize(1));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> row = (Map<String, Object>) rows.get(0);
+        // Every column is named "" so they collide into a single map key; the point of this test
+        // is that the row is NOT an empty {} record with the data silently discarded.
+        assertThat(row.keySet(), contains(""));
+        assertThat(row.get(""), is("4"));
+    }
+
+    @Test
+    void rowMissingHeadersTrailingSeparatorIsFlaggedAsBadLine() throws Exception {
+        // Intended behavior: the field-count check validates against the RAW header field count
+        // (including the trailing unnamed column that gets dropped from the output), so a data row
+        // that leaves off the header's trailing separator is correctly flagged as a bad line rather
+        // than silently accepted.
+        String csvBody = "code_insee;nom_commune;\n1001;L'Abergement-Clémenciat\n"; // data row omits the trailing ';'
+
+        URI src = storageInterface.put(
+            TenantService.MAIN_TENANT, null, URI.create("/rowMissingTrailingSeparator.csv"),
+            new ByteArrayInputStream(csvBody.getBytes(StandardCharsets.UTF_8))
+        );
+
+        CsvToIon reader = CsvToIon.builder()
+            .id("rowMissingHeadersTrailingSeparatorIsFlaggedAsBadLine")
+            .type(CsvToIon.class.getName())
+            .from(Property.ofValue(src.toString()))
+            .fieldSeparator(Property.ofValue(';'))
+            .header(Property.ofValue(true))
+            .onBadLines(Property.ofValue(OnBadLines.ERROR))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of());
+
+        Throwable thrown = assertThrows(RuntimeException.class, () -> reader.run(runContext));
+        assertThat(thrown.getMessage(), containsString("Bad line encountered (field count mismatch): Expected 3, got 2 fields."));
+    }
+
+    @Test
     void badLinesErrorThrows() throws Exception {
         String csv = "header1,header2\nvalue1,value2\nvalue3,value4,value5\nvalue6,value7"; // Bad line: value3,value4,value5
         URI src = storageInterface.put(

--- a/src/test/java/io/kestra/plugin/serdes/csv/CsvToIonWriterTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/csv/CsvToIonWriterTest.java
@@ -268,6 +268,40 @@ class CsvToIonWriterTest {
     }
 
     @Test
+    void emptyHeaderNameInTheMiddleIsPreservedNotDropped() throws Exception {
+        // Only *trailing* empty header names are treated as a trailing-separator artifact. An empty
+        // name in the middle of the header carries real data and is a structural property of the
+        // source file, not an artifact, so it must be preserved rather than silently dropped.
+        String csvBody = "code_insee;;nom_commune\n1001;X;L'Abergement-Clémenciat\n";
+
+        URI src = storageInterface.put(
+            TenantService.MAIN_TENANT, null, URI.create("/middleEmptyHeader.csv"),
+            new ByteArrayInputStream(csvBody.getBytes(StandardCharsets.UTF_8))
+        );
+
+        CsvToIon reader = CsvToIon.builder()
+            .id("emptyHeaderNameInTheMiddleIsPreservedNotDropped")
+            .type(CsvToIon.class.getName())
+            .from(Property.ofValue(src.toString()))
+            .fieldSeparator(Property.ofValue(';'))
+            .header(Property.ofValue(true))
+            .build();
+
+        CsvToIon.Output out = reader.run(TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of()));
+
+        List<Object> rows;
+        try (var in = storageInterface.get(TenantService.MAIN_TENANT, null, out.getUri())) {
+            rows = FileSerde.readAll(in).collectList().block();
+        }
+
+        assertThat(rows, hasSize(1));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> row = (Map<String, Object>) rows.get(0);
+        assertThat(row.keySet(), containsInAnyOrder("code_insee", "", "nom_commune"));
+        assertThat(row.get(""), is("X"));
+    }
+
+    @Test
     void badLinesErrorThrows() throws Exception {
         String csv = "header1,header2\nvalue1,value2\nvalue3,value4,value5\nvalue6,value7"; // Bad line: value3,value4,value5
         URI src = storageInterface.put(

--- a/src/test/java/io/kestra/plugin/serdes/csv/CsvToIonWriterTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/csv/CsvToIonWriterTest.java
@@ -25,6 +25,7 @@ import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.serdes.OnBadLines;
+import io.kestra.plugin.serdes.OnEmptyHeader;
 import io.kestra.plugin.serdes.SerdesUtils;
 
 import de.siegmar.fastcsv.reader.CsvParseException;
@@ -331,6 +332,112 @@ class CsvToIonWriterTest {
         Map<String, Object> row = (Map<String, Object>) rows.get(0);
         assertThat(row.keySet(), not(hasItem("")));
         assertThat(row.keySet(), containsInAnyOrder("code_insee", "nom_commune"));
+    }
+
+    @Test
+    void trailingUnnamedColumnsWithDataAreDroppedByDefault() throws Exception {
+        // Default onEmptyHeader=DROP: trailing columns with an empty header name are dropped even
+        // when the rows carry values there. Documents that data in those columns is not emitted.
+        String csvBody = "id;region;;\n1;north;100;200\n";
+
+        URI src = storageInterface.put(
+            TenantService.MAIN_TENANT, null, URI.create("/trailingUnnamedWithData.csv"),
+            new ByteArrayInputStream(csvBody.getBytes(StandardCharsets.UTF_8))
+        );
+
+        CsvToIon reader = CsvToIon.builder()
+            .id("trailingUnnamedColumnsWithDataAreDroppedByDefault")
+            .type(CsvToIon.class.getName())
+            .from(Property.ofValue(src.toString()))
+            .fieldSeparator(Property.ofValue(';'))
+            .header(Property.ofValue(true))
+            .build();
+
+        CsvToIon.Output out = reader.run(TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of()));
+
+        List<Object> rows;
+        try (var in = storageInterface.get(TenantService.MAIN_TENANT, null, out.getUri())) {
+            rows = FileSerde.readAll(in).collectList().block();
+        }
+
+        assertThat(rows, hasSize(1));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> row = (Map<String, Object>) rows.get(0);
+        assertThat(row.keySet(), containsInAnyOrder("id", "region"));
+        assertThat(row.get("id"), is("1"));
+    }
+
+    @Test
+    void trailingUnnamedColumnsWithDataAreKeptWhenRename() throws Exception {
+        // onEmptyHeader=RENAME: keep every column and give unnamed ones generated names (col_2,
+        // col_3, ...) so no data is lost and downstream conversions get valid column names.
+        String csvBody = "id;region;;\n1;north;100;200\n";
+
+        URI src = storageInterface.put(
+            TenantService.MAIN_TENANT, null, URI.create("/trailingUnnamedRename.csv"),
+            new ByteArrayInputStream(csvBody.getBytes(StandardCharsets.UTF_8))
+        );
+
+        CsvToIon reader = CsvToIon.builder()
+            .id("trailingUnnamedColumnsWithDataAreKeptWhenRename")
+            .type(CsvToIon.class.getName())
+            .from(Property.ofValue(src.toString()))
+            .fieldSeparator(Property.ofValue(';'))
+            .header(Property.ofValue(true))
+            .onEmptyHeader(Property.ofValue(OnEmptyHeader.RENAME))
+            .build();
+
+        CsvToIon.Output out = reader.run(TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of()));
+
+        List<Object> rows;
+        try (var in = storageInterface.get(TenantService.MAIN_TENANT, null, out.getUri())) {
+            rows = FileSerde.readAll(in).collectList().block();
+        }
+
+        assertThat(rows, hasSize(1));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> row = (Map<String, Object>) rows.get(0);
+        assertThat(row.keySet(), containsInAnyOrder("id", "region", "col_2", "col_3"));
+        assertThat(row.get("col_2"), is("100"));
+        assertThat(row.get("col_3"), is("200"));
+    }
+
+    @Test
+    void utf8BomAndTrailingEmptyHeaderTogether() throws Exception {
+        // GitHub issue #17646 as reported: the source file had both a UTF-8 BOM and a trailing
+        // separator. This is the combined regression guard for the exact reported shape.
+        String csvBody = "code_insee;nom_commune;\n1001;L'Abergement-Clémenciat;\n";
+        byte[] utf8Bom = new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+
+        ByteArrayOutputStream withBom = new ByteArrayOutputStream();
+        withBom.write(utf8Bom);
+        withBom.write(csvBody.getBytes(StandardCharsets.UTF_8));
+
+        URI src = storageInterface.put(
+            TenantService.MAIN_TENANT, null, URI.create("/bomAndTrailing.csv"),
+            new ByteArrayInputStream(withBom.toByteArray())
+        );
+
+        CsvToIon reader = CsvToIon.builder()
+            .id("utf8BomAndTrailingEmptyHeaderTogether")
+            .type(CsvToIon.class.getName())
+            .from(Property.ofValue(src.toString()))
+            .fieldSeparator(Property.ofValue(';'))
+            .header(Property.ofValue(true))
+            .build();
+
+        CsvToIon.Output out = reader.run(TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of()));
+
+        List<Object> rows;
+        try (var in = storageInterface.get(TenantService.MAIN_TENANT, null, out.getUri())) {
+            rows = FileSerde.readAll(in).collectList().block();
+        }
+
+        assertThat(rows, hasSize(1));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> row = (Map<String, Object>) rows.get(0);
+        assertThat(row.keySet(), containsInAnyOrder("code_insee", "nom_commune"));
+        assertThat(row.get("code_insee"), is("1001"));
     }
 
     @Test

--- a/src/test/java/io/kestra/plugin/serdes/csv/CsvToIonWriterTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/csv/CsvToIonWriterTest.java
@@ -234,6 +234,45 @@ class CsvToIonWriterTest {
     }
 
     @Test
+    void bomBytesAreNotStrippedForNonUtf8Charset() throws Exception {
+        // EF BB BF is the UTF-8 BOM, but under ISO-8859-1 these are three real characters that
+        // must be preserved, not stripped, so BOM detection is gated on the configured charset.
+        String csvBody = "code_insee;nom_commune\n1001;Abergement\n";
+        byte[] utf8Bom = new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+
+        ByteArrayOutputStream withBom = new ByteArrayOutputStream();
+        withBom.write(utf8Bom);
+        withBom.write(csvBody.getBytes(StandardCharsets.ISO_8859_1));
+
+        URI src = storageInterface.put(
+            TenantService.MAIN_TENANT, null, URI.create("/bomNonUtf8.csv"),
+            new ByteArrayInputStream(withBom.toByteArray())
+        );
+
+        CsvToIon reader = CsvToIon.builder()
+            .id("bomBytesAreNotStrippedForNonUtf8Charset")
+            .type(CsvToIon.class.getName())
+            .from(Property.ofValue(src.toString()))
+            .fieldSeparator(Property.ofValue(';'))
+            .charset(Property.ofValue("ISO-8859-1"))
+            .header(Property.ofValue(true))
+            .build();
+
+        CsvToIon.Output out = reader.run(TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of()));
+
+        List<Object> rows;
+        try (var in = storageInterface.get(TenantService.MAIN_TENANT, null, out.getUri())) {
+            rows = FileSerde.readAll(in).collectList().block();
+        }
+
+        assertThat(rows, hasSize(1));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> row = (Map<String, Object>) rows.get(0);
+        assertThat(row.keySet(), not(hasItem("code_insee")));
+        assertThat(row.keySet(), hasItem("ï»¿code_insee"));
+    }
+
+    @Test
     void trailingEmptyHeaderColumnIsDropped() throws Exception {
         String csvBody = "code_insee;nom_commune;\n1001;L'Abergement-Clémenciat;\n";
 
@@ -574,12 +613,13 @@ class CsvToIonWriterTest {
 
     @Test
     void badLinesWarnAndSkip() throws Exception {
-        String csv = "header1,header2\nvalue1,value2\nvalue3,\"value4\nvalue6,value7\nvalue8,value9,value10\nvalue11,value12";
+        String csv = "header1,header2\nvalue1,value2\nvalue3,\"value4\nvalue6,value7\nvalue8,value9,value10\nvalue11,value12"; // Bad lines: value3,"value4 (unclosed quote), value8,value9,value10 (field count mismatch)
         URI src = storageInterface.put(
             TenantService.MAIN_TENANT, null, URI.create("/badLinesWarnSkip.csv"),
             new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8))
         );
 
+        // Test WARN
         CsvToIon readerWarn = CsvToIon.builder()
             .id("badLinesWarn")
             .type(CsvToIon.class.getName())
@@ -597,8 +637,9 @@ class CsvToIonWriterTest {
             .findFirst()
             .get();
 
-        assertThat(recordsWarn.getValue(), is(2D));
+        assertThat(recordsWarn.getValue(), is(2D)); // header + 3 good lines processed, 2 bad lines skipped
 
+        // Test SKIP
         CsvToIon readerSkip = CsvToIon.builder()
             .id("badLinesSkip")
             .type(CsvToIon.class.getName())
@@ -616,21 +657,23 @@ class CsvToIonWriterTest {
             .findFirst()
             .get();
 
-        assertThat(recordsSkip.getValue(), is(2D));
+        assertThat(recordsSkip.getValue(), is(2D)); // header + 3 good lines processed, 2 bad lines skipped
     }
 
     @Test
     void testCsvWithBadRows() throws Exception {
         String csv = "name,age,city\n" +
-            "Alice,New York\n" +
-            "Bob,25,London,extra\n" +
-            "Charlie,35,Paris";
+            "Alice,New York\n" + // less column → bad row
+            "Bob,25,London,extra\n" + // extra column → bad row
+            "Charlie,35,Paris"; // correct row
 
+        // Put CSV in storage
         URI src = storageInterface.put(
             TenantService.MAIN_TENANT, null, URI.create("/badRows.csv"),
             new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8))
         );
 
+        // WARN mode
         CsvToIon readerWarn = CsvToIon.builder()
             .id("badRowsTestWarn")
             .type(CsvToIon.class.getName())
@@ -649,6 +692,7 @@ class CsvToIonWriterTest {
             .orElseThrow();
         assertThat(recordsWarn.getValue(), is(1D));
 
+        // SKIP mode
         CsvToIon readerSkip = CsvToIon.builder()
             .id("badRowsTestSkip")
             .type(CsvToIon.class.getName())
@@ -667,6 +711,7 @@ class CsvToIonWriterTest {
             .orElseThrow();
         assertThat(recordsSkip.getValue(), is(1D));
 
+        // ERROR mode
         CsvToIon readerError = CsvToIon.builder()
             .id("badRowsTestError")
             .type(CsvToIon.class.getName())

--- a/src/test/java/io/kestra/plugin/serdes/csv/CsvToIonWriterTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/csv/CsvToIonWriterTest.java
@@ -403,6 +403,80 @@ class CsvToIonWriterTest {
     }
 
     @Test
+    void renameDisambiguatesAgainstRealColumnNamedLikeGenerated() throws Exception {
+        // RENAME must not overwrite a real column that happens to be named like a generated one.
+        // Here index 1 is empty (would generate "col_1") and index 2 is literally named "col_1";
+        // the generated name is disambiguated so all four columns and their values survive.
+        String csvBody = "a;;col_1;d\n1;2;3;4\n";
+
+        URI src = storageInterface.put(
+            TenantService.MAIN_TENANT, null, URI.create("/renameCollision.csv"),
+            new ByteArrayInputStream(csvBody.getBytes(StandardCharsets.UTF_8))
+        );
+
+        CsvToIon reader = CsvToIon.builder()
+            .id("renameDisambiguatesAgainstRealColumnNamedLikeGenerated")
+            .type(CsvToIon.class.getName())
+            .from(Property.ofValue(src.toString()))
+            .fieldSeparator(Property.ofValue(';'))
+            .header(Property.ofValue(true))
+            .onEmptyHeader(Property.ofValue(OnEmptyHeader.RENAME))
+            .build();
+
+        CsvToIon.Output out = reader.run(TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of()));
+
+        List<Object> rows;
+        try (var in = storageInterface.get(TenantService.MAIN_TENANT, null, out.getUri())) {
+            rows = FileSerde.readAll(in).collectList().block();
+        }
+
+        assertThat(rows, hasSize(1));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> row = (Map<String, Object>) rows.get(0);
+        // 4 distinct keys: the real "col_1" is preserved, the generated one gets "col_1_2".
+        assertThat(row.keySet(), hasSize(4));
+        assertThat(row.keySet(), hasItems("a", "col_1", "d"));
+        assertThat(row.get("col_1"), is("3"));
+        assertThat(row.get("col_1_2"), is("2"));
+    }
+
+    @Test
+    void renameNamesMiddleAndAllEmptyHeaders() throws Exception {
+        // RENAME renames every empty header name, including one in the middle and the all-empty case,
+        // so no column collapses to an unusable "" name and no data is lost.
+        String csvBody = ";b;\n1;2;3\n";
+
+        URI src = storageInterface.put(
+            TenantService.MAIN_TENANT, null, URI.create("/renameMiddleAndEdges.csv"),
+            new ByteArrayInputStream(csvBody.getBytes(StandardCharsets.UTF_8))
+        );
+
+        CsvToIon reader = CsvToIon.builder()
+            .id("renameNamesMiddleAndAllEmptyHeaders")
+            .type(CsvToIon.class.getName())
+            .from(Property.ofValue(src.toString()))
+            .fieldSeparator(Property.ofValue(';'))
+            .header(Property.ofValue(true))
+            .onEmptyHeader(Property.ofValue(OnEmptyHeader.RENAME))
+            .build();
+
+        CsvToIon.Output out = reader.run(TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of()));
+
+        List<Object> rows;
+        try (var in = storageInterface.get(TenantService.MAIN_TENANT, null, out.getUri())) {
+            rows = FileSerde.readAll(in).collectList().block();
+        }
+
+        assertThat(rows, hasSize(1));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> row = (Map<String, Object>) rows.get(0);
+        assertThat(row.keySet(), containsInAnyOrder("col_0", "b", "col_2"));
+        assertThat(row.get("col_0"), is("1"));
+        assertThat(row.get("b"), is("2"));
+        assertThat(row.get("col_2"), is("3"));
+    }
+
+    @Test
     void utf8BomAndTrailingEmptyHeaderTogether() throws Exception {
         // GitHub issue #17646 as reported: the source file had both a UTF-8 BOM and a trailing
         // separator. This is the combined regression guard for the exact reported shape.

--- a/src/test/java/io/kestra/plugin/serdes/csv/CsvToIonWriterTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/csv/CsvToIonWriterTest.java
@@ -199,8 +199,6 @@ class CsvToIonWriterTest {
 
     @Test
     void utf8BomInHeaderIsStripped() throws Exception {
-        // GitHub issue #17646: a UTF-8 BOM at the start of the file was leaking into the first
-        // header's name, causing it to be quoted differently from every other field in the Ion output.
         String csvBody = "code_insee;nom_commune\n1001;L'Abergement-Clémenciat\n";
         byte[] utf8Bom = new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
 
@@ -237,8 +235,6 @@ class CsvToIonWriterTest {
 
     @Test
     void trailingEmptyHeaderColumnIsDropped() throws Exception {
-        // GitHub issue #17646: a trailing field separator on the header line produced a
-        // nameless field ('':"") on every row in the Ion output.
         String csvBody = "code_insee;nom_commune;\n1001;L'Abergement-Clémenciat;\n";
 
         URI src = storageInterface.put(
@@ -270,9 +266,6 @@ class CsvToIonWriterTest {
 
     @Test
     void emptyHeaderNameInTheMiddleIsPreservedNotDropped() throws Exception {
-        // Only *trailing* empty header names are treated as a trailing-separator artifact. An empty
-        // name in the middle of the header carries real data and is a structural property of the
-        // source file, not an artifact, so it must be preserved rather than silently dropped.
         String csvBody = "code_insee;;nom_commune\n1001;X;L'Abergement-Clémenciat\n";
 
         URI src = storageInterface.put(
@@ -304,7 +297,6 @@ class CsvToIonWriterTest {
 
     @Test
     void multipleTrailingEmptyHeaderColumnsAreDropped() throws Exception {
-        // Two trailing separators in a row should drop both empty-named trailing columns, not just one.
         String csvBody = "code_insee;nom_commune;;\n1001;L'Abergement-Clémenciat;;\n";
 
         URI src = storageInterface.put(
@@ -336,8 +328,6 @@ class CsvToIonWriterTest {
 
     @Test
     void trailingUnnamedColumnsWithDataAreDroppedByDefault() throws Exception {
-        // Default onEmptyHeader=DROP: trailing columns with an empty header name are dropped even
-        // when the rows carry values there. Documents that data in those columns is not emitted.
         String csvBody = "id;region;;\n1;north;100;200\n";
 
         URI src = storageInterface.put(
@@ -369,8 +359,6 @@ class CsvToIonWriterTest {
 
     @Test
     void trailingUnnamedColumnsWithDataAreKeptWhenRename() throws Exception {
-        // onEmptyHeader=RENAME: keep every column and give unnamed ones generated names (col_2,
-        // col_3, ...) so no data is lost and downstream conversions get valid column names.
         String csvBody = "id;region;;\n1;north;100;200\n";
 
         URI src = storageInterface.put(
@@ -404,9 +392,6 @@ class CsvToIonWriterTest {
 
     @Test
     void renameDisambiguatesAgainstRealColumnNamedLikeGenerated() throws Exception {
-        // RENAME must not overwrite a real column that happens to be named like a generated one.
-        // Here index 1 is empty (would generate "col_1") and index 2 is literally named "col_1";
-        // the generated name is disambiguated so all four columns and their values survive.
         String csvBody = "a;;col_1;d\n1;2;3;4\n";
 
         URI src = storageInterface.put(
@@ -433,7 +418,6 @@ class CsvToIonWriterTest {
         assertThat(rows, hasSize(1));
         @SuppressWarnings("unchecked")
         Map<String, Object> row = (Map<String, Object>) rows.get(0);
-        // 4 distinct keys: the real "col_1" is preserved, the generated one gets "col_1_2".
         assertThat(row.keySet(), hasSize(4));
         assertThat(row.keySet(), hasItems("a", "col_1", "d"));
         assertThat(row.get("col_1"), is("3"));
@@ -442,8 +426,6 @@ class CsvToIonWriterTest {
 
     @Test
     void renameNamesMiddleAndAllEmptyHeaders() throws Exception {
-        // RENAME renames every empty header name, including one in the middle and the all-empty case,
-        // so no column collapses to an unusable "" name and no data is lost.
         String csvBody = ";b;\n1;2;3\n";
 
         URI src = storageInterface.put(
@@ -478,8 +460,6 @@ class CsvToIonWriterTest {
 
     @Test
     void utf8BomAndTrailingEmptyHeaderTogether() throws Exception {
-        // GitHub issue #17646 as reported: the source file had both a UTF-8 BOM and a trailing
-        // separator. This is the combined regression guard for the exact reported shape.
         String csvBody = "code_insee;nom_commune;\n1001;L'Abergement-Clémenciat;\n";
         byte[] utf8Bom = new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
 
@@ -516,9 +496,6 @@ class CsvToIonWriterTest {
 
     @Test
     void allEmptyHeaderIsNotTrimmedToZeroColumns() throws Exception {
-        // Edge case: if the whole header is empty (e.g. ";;;"), trimming every column would leave
-        // zero columns and every row would collapse to an empty record. There's no "real" header
-        // left to anchor the trim against, so nothing is dropped in this case.
         String csvBody = ";;;\n1;2;3;4\n";
 
         URI src = storageInterface.put(
@@ -544,19 +521,13 @@ class CsvToIonWriterTest {
         assertThat(rows, hasSize(1));
         @SuppressWarnings("unchecked")
         Map<String, Object> row = (Map<String, Object>) rows.get(0);
-        // Every column is named "" so they collide into a single map key; the point of this test
-        // is that the row is NOT an empty {} record with the data silently discarded.
         assertThat(row.keySet(), contains(""));
         assertThat(row.get(""), is("4"));
     }
 
     @Test
     void rowMissingHeadersTrailingSeparatorIsFlaggedAsBadLine() throws Exception {
-        // Intended behavior: the field-count check validates against the RAW header field count
-        // (including the trailing unnamed column that gets dropped from the output), so a data row
-        // that leaves off the header's trailing separator is correctly flagged as a bad line rather
-        // than silently accepted.
-        String csvBody = "code_insee;nom_commune;\n1001;L'Abergement-Clémenciat\n"; // data row omits the trailing ';'
+        String csvBody = "code_insee;nom_commune;\n1001;L'Abergement-Clémenciat\n";
 
         URI src = storageInterface.put(
             TenantService.MAIN_TENANT, null, URI.create("/rowMissingTrailingSeparator.csv"),
@@ -580,7 +551,7 @@ class CsvToIonWriterTest {
 
     @Test
     void badLinesErrorThrows() throws Exception {
-        String csv = "header1,header2\nvalue1,value2\nvalue3,value4,value5\nvalue6,value7"; // Bad line: value3,value4,value5
+        String csv = "header1,header2\nvalue1,value2\nvalue3,value4,value5\nvalue6,value7";
         URI src = storageInterface.put(
             TenantService.MAIN_TENANT, null, URI.create("/badLinesError.csv"),
             new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8))
@@ -603,13 +574,12 @@ class CsvToIonWriterTest {
 
     @Test
     void badLinesWarnAndSkip() throws Exception {
-        String csv = "header1,header2\nvalue1,value2\nvalue3,\"value4\nvalue6,value7\nvalue8,value9,value10\nvalue11,value12"; // Bad lines: value3,"value4 (unclosed quote), value8,value9,value10 (field count mismatch)
+        String csv = "header1,header2\nvalue1,value2\nvalue3,\"value4\nvalue6,value7\nvalue8,value9,value10\nvalue11,value12";
         URI src = storageInterface.put(
             TenantService.MAIN_TENANT, null, URI.create("/badLinesWarnSkip.csv"),
             new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8))
         );
 
-        // Test WARN
         CsvToIon readerWarn = CsvToIon.builder()
             .id("badLinesWarn")
             .type(CsvToIon.class.getName())
@@ -627,9 +597,8 @@ class CsvToIonWriterTest {
             .findFirst()
             .get();
 
-        assertThat(recordsWarn.getValue(), is(2D)); // header + 3 good lines processed, 2 bad lines skipped
+        assertThat(recordsWarn.getValue(), is(2D));
 
-        // Test SKIP
         CsvToIon readerSkip = CsvToIon.builder()
             .id("badLinesSkip")
             .type(CsvToIon.class.getName())
@@ -647,23 +616,21 @@ class CsvToIonWriterTest {
             .findFirst()
             .get();
 
-        assertThat(recordsSkip.getValue(), is(2D)); // header + 3 good lines processed, 2 bad lines skipped
+        assertThat(recordsSkip.getValue(), is(2D));
     }
 
     @Test
     void testCsvWithBadRows() throws Exception {
         String csv = "name,age,city\n" +
-            "Alice,New York\n" + // less column → bad row
-            "Bob,25,London,extra\n" + // extra column → bad row
-            "Charlie,35,Paris"; // correct row
+            "Alice,New York\n" +
+            "Bob,25,London,extra\n" +
+            "Charlie,35,Paris";
 
-        // Put CSV in storage
         URI src = storageInterface.put(
             TenantService.MAIN_TENANT, null, URI.create("/badRows.csv"),
             new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8))
         );
 
-        // WARN mode
         CsvToIon readerWarn = CsvToIon.builder()
             .id("badRowsTestWarn")
             .type(CsvToIon.class.getName())
@@ -682,7 +649,6 @@ class CsvToIonWriterTest {
             .orElseThrow();
         assertThat(recordsWarn.getValue(), is(1D));
 
-        // SKIP mode
         CsvToIon readerSkip = CsvToIon.builder()
             .id("badRowsTestSkip")
             .type(CsvToIon.class.getName())
@@ -701,7 +667,6 @@ class CsvToIonWriterTest {
             .orElseThrow();
         assertThat(recordsSkip.getValue(), is(1D));
 
-        // ERROR mode
         CsvToIon readerError = CsvToIon.builder()
             .id("badRowsTestError")
             .type(CsvToIon.class.getName())

--- a/src/test/java/io/kestra/plugin/serdes/csv/CsvToIonWriterTest.java
+++ b/src/test/java/io/kestra/plugin/serdes/csv/CsvToIonWriterTest.java
@@ -1,12 +1,14 @@
 package io.kestra.plugin.serdes.csv;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -192,6 +194,77 @@ class CsvToIonWriterTest {
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of());
         CsvToIon.Output out = reader.run(runContext);
         assertThat(out.getUri(), is(notNullValue()));
+    }
+
+    @Test
+    void utf8BomInHeaderIsStripped() throws Exception {
+        // GitHub issue #17646: a UTF-8 BOM at the start of the file was leaking into the first
+        // header's name, causing it to be quoted differently from every other field in the Ion output.
+        String csvBody = "code_insee;nom_commune\n1001;L'Abergement-Clémenciat\n";
+        byte[] utf8Bom = new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+
+        ByteArrayOutputStream withBom = new ByteArrayOutputStream();
+        withBom.write(utf8Bom);
+        withBom.write(csvBody.getBytes(StandardCharsets.UTF_8));
+
+        URI src = storageInterface.put(
+            TenantService.MAIN_TENANT, null, URI.create("/bomHeader.csv"),
+            new ByteArrayInputStream(withBom.toByteArray())
+        );
+
+        CsvToIon reader = CsvToIon.builder()
+            .id("utf8BomInHeaderIsStripped")
+            .type(CsvToIon.class.getName())
+            .from(Property.ofValue(src.toString()))
+            .fieldSeparator(Property.ofValue(';'))
+            .header(Property.ofValue(true))
+            .build();
+
+        CsvToIon.Output out = reader.run(TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of()));
+
+        List<Object> rows;
+        try (var in = storageInterface.get(TenantService.MAIN_TENANT, null, out.getUri())) {
+            rows = FileSerde.readAll(in).collectList().block();
+        }
+
+        assertThat(rows, hasSize(1));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> row = (Map<String, Object>) rows.get(0);
+        assertThat(row.keySet(), hasItem("code_insee"));
+        assertThat(row.get("code_insee"), is("1001"));
+    }
+
+    @Test
+    void trailingEmptyHeaderColumnIsDropped() throws Exception {
+        // GitHub issue #17646: a trailing field separator on the header line produced a
+        // nameless field ('':"") on every row in the Ion output.
+        String csvBody = "code_insee;nom_commune;\n1001;L'Abergement-Clémenciat;\n";
+
+        URI src = storageInterface.put(
+            TenantService.MAIN_TENANT, null, URI.create("/trailingEmptyHeader.csv"),
+            new ByteArrayInputStream(csvBody.getBytes(StandardCharsets.UTF_8))
+        );
+
+        CsvToIon reader = CsvToIon.builder()
+            .id("trailingEmptyHeaderColumnIsDropped")
+            .type(CsvToIon.class.getName())
+            .from(Property.ofValue(src.toString()))
+            .fieldSeparator(Property.ofValue(';'))
+            .header(Property.ofValue(true))
+            .build();
+
+        CsvToIon.Output out = reader.run(TestsUtils.mockRunContext(runContextFactory, reader, ImmutableMap.of()));
+
+        List<Object> rows;
+        try (var in = storageInterface.get(TenantService.MAIN_TENANT, null, out.getUri())) {
+            rows = FileSerde.readAll(in).collectList().block();
+        }
+
+        assertThat(rows, hasSize(1));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> row = (Map<String, Object>) rows.get(0);
+        assertThat(row.keySet(), not(hasItem("")));
+        assertThat(row.keySet(), containsInAnyOrder("code_insee", "nom_commune"));
     }
 
     @Test


### PR DESCRIPTION
## What
Fixes two bugs in `CsvToIon` reported in kestra-io/kestra#17646.

## Why
1. A UTF-8 BOM at the start of a CSV file was leaking into the first header's
   name, causing only that field to be quoted (inconsistently with every
   other field) in the resulting Ion output.
2. A trailing field separator on the header line produced a nameless empty
   field on every row, which broke downstream `IonToParquet` conversion
   (Parquet requires real column names).

## Before / After
Reproduced with the exact sample data from the issue (French INSEE radiation
dataset, `;`-separated, UTF-8 BOM):

**Before:**
{'﻿code_insee':"1001",nom_commune:"L'Abergement-Clémenciat",code_departement:"1",...}

**After:**
{code_insee:"1001",nom_commune:"L'Abergement-Clémenciat",code_departement:"1",...}

## How
- Strip a leading UTF-8 BOM using Apache commons-io `BOMInputStream` before the
  CSV parser reads the stream. commons-io is declared as an explicit dependency,
  version managed by the `io.kestra:platform` BOM.
- Handle empty-named header columns via a new `onEmptyHeader` property:
  - `DROP` (default): drop trailing unnamed columns and log a warning. If the
    whole header is empty, keep every column instead of collapsing rows to `{}`.
  - `RENAME`: keep every column and name unnamed ones `col_0`, `col_1`, ...,
    disambiguated so a generated name never overwrites a real column that already
    has that name. No data is lost.
- Row field counts are still validated against the raw header count, so
  `onBadLines` detection is unaffected. An empty header name in the middle of the
  header is preserved as-is (structural data, not a trailing-separator artifact).

## Testing
`CsvToIonWriterTest` covers: BOM stripping, BOM plus a trailing separator together,
single and multiple trailing empty columns, an all-empty header, a middle empty
header, `DROP` vs `RENAME` on data-bearing trailing columns, the `RENAME`
name-collision case, and a row missing the header's trailing separator being
flagged as a bad line.

Full `CsvToIonWriterTest` suite: 20 passing, 0 failing.

Fixes kestra-io/kestra#17646
